### PR TITLE
Bring back --all support for drive listing

### DIFF
--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -91,6 +91,9 @@ func listDrives(ctx context.Context, args []string) error {
 		ctx,
 		utils.GetDirectCSIClient().DirectCSIDrives(),
 		func(drive directcsi.DirectCSIDrive) bool {
+			if drive.Status.DriveStatus == directcsi.DriveStatusUnavailable && !all {
+				return false
+			}
 			return drive.MatchGlob(nodes, drives, status) && drive.MatchAccessTier(accessTierSet)
 		},
 	)


### PR DESCRIPTION
Unvailable drives should be displayed only when `--all` flag is specified.