### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/direct-csi/run.go
+++ b/cmd/direct-csi/run.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -56,7 +55,7 @@ func waitForConversionWebhook() error {
 		return errInvalidConversionHealthzURL
 	}
 
-	caCert, err := ioutil.ReadFile(conversionCAFile)
+	caCert, err := os.ReadFile(conversionCAFile)
 	if err != nil {
 		klog.V(2).Infof("Error while reading cacert %v", err)
 		return err

--- a/pkg/controller/validation-handlers.go
+++ b/pkg/controller/validation-handlers.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta3"
@@ -46,7 +46,7 @@ func parseAdmissionReview(req *http.Request) (admissionv1.AdmissionReview, error
 	}
 
 	if req.Body != nil {
-		if data, err := ioutil.ReadAll(req.Body); err == nil {
+		if data, err := io.ReadAll(req.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/converter/framework.go
+++ b/pkg/converter/framework.go
@@ -18,7 +18,7 @@ package converter
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +45,7 @@ var supportedVersions = []string{
 	versionV1Beta1,
 	versionV1Beta2,
 	versionV1Beta3,
-} //ordered
+} // ordered
 
 type crdKind string
 
@@ -112,7 +112,7 @@ func doConversion(convertRequest *v1.ConversionRequest, convert convertFunc) *v1
 func serve(w http.ResponseWriter, r *http.Request, convert convertFunc) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -19,7 +19,6 @@ package listener
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -52,7 +51,7 @@ func getNamespace() string {
 		return ns
 	}
 
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); ns != "" {
 			return ns
 		}

--- a/pkg/node/publish_unpublish_test.go
+++ b/pkg/node/publish_unpublish_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestPublishUnpublishVolume(t *testing.T) {
 	testVolumeName50MB := "test_volume_50MB"
 
 	createTestDir := func(prefix string) (string, error) {
-		tDir, err := ioutil.TempDir("", prefix)
+		tDir, err := os.MkdirTemp("", prefix)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/node/stage_unstage_test.go
+++ b/pkg/node/stage_unstage_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +44,7 @@ func TestStageUnstageVolume(t *testing.T) {
 	testDriveName := "test_drive"
 	testVolumeName50MB := "test_volume_50MB"
 
-	testMountPointDir, err := ioutil.TempDir("", "test_")
+	testMountPointDir, err := os.MkdirTemp("", "test_")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sys/loopback/utils.go
+++ b/pkg/sys/loopback/utils.go
@@ -19,7 +19,6 @@ package loopback
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,7 +28,7 @@ import (
 func prepareBackingFile(loopDevNum uint64) (string, error) {
 	backingFile := filepath.Join(DirectCSIBackFileRoot, fmt.Sprintf("loop%d", uint64(loopDevNum)))
 	bytesToWrite := make([]byte, backFileSize)
-	return backingFile, ioutil.WriteFile(backingFile, bytesToWrite, 0666)
+	return backingFile, os.WriteFile(backingFile, bytesToWrite, 0666)
 }
 
 func getDeviceFileName(ldNumber uint64) string {

--- a/pkg/sys/sys_utils.go
+++ b/pkg/sys/sys_utils.go
@@ -19,7 +19,6 @@ package sys
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -140,7 +139,7 @@ func FlushLoopBackReservations() error {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(loopback.DirectCSIBackFileRoot)
+	files, err := os.ReadDir(loopback.DirectCSIBackFileRoot)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.