### PR TITLE
Do not use standard port `:80` for metrics server

### DIFF
--- a/cmd/directpv/cmd.go
+++ b/cmd/directpv/cmd.go
@@ -50,6 +50,7 @@ var (
 	showVersion           = false
 	conversionHealthzURL  = ""
 	dynamicDriveDiscovery = false
+	metricsPort           = 10443
 )
 
 var driverCmd = &cobra.Command{
@@ -109,6 +110,7 @@ func init() {
 	driverCmd.Flags().BoolVarP(&loopbackOnly, "loopback-only", "", loopbackOnly, "Create and use loopback devices (FOR TESTING ONLY)")
 	driverCmd.Flags().StringVarP(&conversionHealthzURL, "conversion-healthz-url", "", conversionHealthzURL, "The URL of the conversion webhook healthz endpoint")
 	driverCmd.Flags().BoolVarP(&dynamicDriveDiscovery, "dynamic-drive-discovery", "", dynamicDriveDiscovery, "Enable dynamic drive discovery (disabled by default)")
+	driverCmd.Flags().IntVarP(&metricsPort, "metrics-port", "", metricsPort, "Metrics port for scraping. default is 10443")
 
 	driverCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	driverCmd.PersistentFlags().MarkHidden("log_backtrace_at")

--- a/cmd/directpv/run.go
+++ b/cmd/directpv/run.go
@@ -182,7 +182,7 @@ func run(ctx context.Context, args []string) error {
 			klog.V(3).Infof("This flag will be made default in the next major release version")
 		}
 
-		nodeSrv, err = node.NewNodeServer(ctx, identity, nodeID, rack, zone, region, dynamicDriveDiscovery, reflinkSupport, loopbackOnly)
+		nodeSrv, err = node.NewNodeServer(ctx, identity, nodeID, rack, zone, region, dynamicDriveDiscovery, reflinkSupport, loopbackOnly, metricsPort)
 		if err != nil {
 			return err
 		}

--- a/pkg/installer/const.go
+++ b/pkg/installer/const.go
@@ -100,4 +100,8 @@ const (
 	createdByLabel = "created-by"
 	appNameLabel   = "application-name"
 	appTypeLabel   = "application-type"
+
+	// metrics
+	metricsPortName = "metrics"
+	metricsPort     = 10443
 )

--- a/pkg/installer/daemonset.go
+++ b/pkg/installer/daemonset.go
@@ -140,6 +140,7 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 						fmt.Sprintf("--endpoint=$(%s)", endpointEnvVarCSI),
 						fmt.Sprintf("--node-id=$(%s)", kubeNodeNameEnvVar),
 						fmt.Sprintf("--conversion-healthz-url=%s", c.conversionHealthzURL()),
+						fmt.Sprintf("--metrics-port=%d", metricsPort),
 						"--driver",
 					}
 					if c.LoopbackMode {
@@ -178,6 +179,11 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 					{
 						ContainerPort: conversionWebhookPort,
 						Name:          conversionWebhookPortName,
+						Protocol:      corev1.ProtocolTCP,
+					},
+					{
+						ContainerPort: metricsPort,
+						Name:          metricsPortName,
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,10 +25,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const port = "80"
-
 // ServeMetrics starts metrics service.
-func ServeMetrics(ctx context.Context, nodeID string) {
+func ServeMetrics(ctx context.Context, nodeID string, port int) {
 
 	server := &http.Server{
 		Handler: metricsHandler(nodeID),
@@ -40,7 +38,7 @@ func ServeMetrics(ctx context.Context, nodeID string) {
 		panic(lErr)
 	}
 
-	klog.V(2).Infof("Starting metrics exporter in port: %s", port)
+	klog.V(2).Infof("Starting metrics exporter in port: %d", port)
 	if err := server.Serve(listener); err != nil {
 		klog.Errorf("Failed to listen and serve metrics server: %v", err)
 		if err != http.ErrServerClosed {

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -55,7 +55,7 @@ func (c *metricsCollector) getxfsVolumeStats(ctx context.Context, vol *directcsi
 	if err != nil {
 		return xfsVolumeStats{}, err
 	}
-	quota, err := xfs.GetQuota(ctx, device, vol.Name)
+	quota, err := xfs.GetQuota(ctx, "/dev/"+device, vol.Name)
 	if err != nil {
 		return xfsVolumeStats{}, err
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -67,7 +67,7 @@ type NodeServer struct { //revive:disable-line:exported
 //revive:enable-line:exported
 
 // NewNodeServer creates node server.
-func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region string, dynamicDriveDiscovery, reflinkSupport, loopbackOnly bool) (*NodeServer, error) {
+func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region string, dynamicDriveDiscovery, reflinkSupport, loopbackOnly bool, metricsPort int) (*NodeServer, error) {
 	config, err := client.GetKubeConfig()
 	if err != nil {
 		return &NodeServer{}, err
@@ -131,7 +131,7 @@ func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region str
 		}
 	}()
 
-	go metrics.ServeMetrics(ctx, nodeID)
+	go metrics.ServeMetrics(ctx, nodeID, metricsPort)
 
 	return nodeServer, nil
 }
@@ -158,7 +158,7 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 // NodeGetCapabilities gets node capabilities.
 func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	nodeCap := func(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeServiceCapability {
-		klog.V(2).Infof("Using node capability %v", cap)
+		klog.V(5).Infof("Using node capability %v", cap)
 
 		return &csi.NodeServiceCapability{
 			Type: &csi.NodeServiceCapability_Rpc{


### PR DESCRIPTION
- As directpv daemonset runs with hostnetwork: true, standard ports can be avoided.
- This PR will fix the crash when `:80` is already in use by host.
- Also fixes a bug in metrics export, where the device name was not set properly.