### PR TITLE
Add more privilege

### DIFF
--- a/pkg/installer/const.go
+++ b/pkg/installer/const.go
@@ -24,6 +24,7 @@ const (
 
 	// rbac
 	clusterRoleVerbList   = "list"
+	clusterRoleVerbUse    = "use"
 	clusterRoleVerbGet    = "get"
 	clusterRoleVerbWatch  = "watch"
 	clusterRoleVerbCreate = "create"

--- a/pkg/installer/psp.go
+++ b/pkg/installer/psp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/utils"
 
+	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,7 @@ import (
 )
 
 func createPodSecurityPolicy(ctx context.Context, i *Config) error {
+
 	pspObj := &policy.PodSecurityPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "policy/v1beta1",
@@ -42,9 +44,11 @@ func createPodSecurityPolicy(ctx context.Context, i *Config) error {
 			Labels:      defaultLabels,
 		},
 		Spec: policy.PodSecurityPolicySpec{
-			Privileged: true,
-			HostPID:    true,
-			HostIPC:    true,
+			Privileged:          true,
+			HostPID:             true,
+			HostIPC:             true,
+			AllowedCapabilities: []corev1.Capability{policy.AllowAllCapabilities},
+			Volumes:             []policy.FSType{policy.HostPath},
 			AllowedHostPaths: []policy.AllowedHostPath{
 				{PathPrefix: "/proc", ReadOnly: true},
 				{PathPrefix: "/sys", ReadOnly: true},

--- a/pkg/installer/rbac.go
+++ b/pkg/installer/rbac.go
@@ -128,6 +128,11 @@ func createClusterRole(ctx context.Context, c *Config) error {
 				},
 			},
 			{
+				Verbs:     []string{clusterRoleVerbUse},
+				Resources: []string{"podsecuritypolicies"},
+				APIGroups: []string{"policy"},
+			},
+			{
 				Verbs: []string{
 					clusterRoleVerbGet,
 					clusterRoleVerbList,


### PR DESCRIPTION
The Pod security policy were not applied on the nodes. 
To apply the psp on the nodes modified the rbac .
**How to Test**
*1. Start minikube using the command*
```
minikube start --extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy --addons=pod-security-policy
```

*2. Run with master branch*
```
ashish@ashish:~/code/go/src/github/minio/directpv$ git branch
  curl
  functional-test
* master
  modify-functional-test
  psp
  readme
ashish@ashish:~/code/go/src/github/minio/directpv$ go build ./cmd/kubectl-directpv/
ashish@ashish:~/code/go/src/github/minio/directpv$ ./kubectl-directpv install --image directpv:v2.0.2 
I0127 15:49:07.870698 1010113 install.go:95] Enable dynamic drive change management using --enable-dynamic-discovery flag
I0127 15:49:07.870723 1010113 install.go:96] This flag will be made default in the next major release version
I0127 15:49:07.878338 1010113 ns.go:55] 'direct.csi.min.io' namespace created
I0127 15:49:07.885312 1010113 rbac.go:347] 'direct.csi.min.io' rbac created
W0127 15:49:07.894126 1010113 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
I0127 15:49:07.899257 1010113 psp.go:125] 'direct.csi.min.io' podsecuritypolicy created
I0127 15:49:12.010070 1010113 conversion_secret.go:170] 'direct.csi.min.io' conversion webhook secrets created
I0127 15:49:12.049163 1010113 crd.go:135] crds successfully registered
I0127 15:49:12.060148 1010113 csidriver.go:150] 'direct.csi.min.io' csidriver created
I0127 15:49:12.095981 1010113 storageclass.go:50] 'direct.csi.min.io' storageclass created
I0127 15:49:12.103529 1010113 service.go:39] 'direct.csi.min.io' service created
I0127 15:49:12.116752 1010113 daemonset.go:41] 'direct.csi.min.io' daemonset created
I0127 15:49:12.183806 1010113 deployment.go:295] 'direct.csi.min.io' deployment created
ashish@ashish:~/code/go/src/github/minio/directpv$ kubectl get nodes -n direct-csi-min-io
NAME       STATUS   ROLES                  AGE     VERSION
minikube   Ready    control-plane,master   4m32s   v1.22.3
ashish@ashish:~/code/go/src/github/minio/directpv$ kubectl get pods -n direct-csi-min-io
No resources found in direct-csi-min-io namespace.
ashish@ashish:~/code/go/src/github/minio/directpv$ kubectl get events -n direct-csi-min-io
LAST SEEN   TYPE      REASON              OBJECT                                   MESSAGE
18s         Warning   FailedCreate        replicaset/direct-csi-min-io-b7f886bdc   Error creating: pods "direct-csi-min-io-b7f886bdc-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[1].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
18s         Warning   FailedCreate        daemonset/direct-csi-min-io              Error creating: pods "direct-csi-min-io-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used spec.securityContext.hostIPC: Invalid value: true: Host IPC is not allowed to be used spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[7]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[8]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[1].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
38s         Normal    ScalingReplicaSet   deployment/direct-csi-min-io             Scaled up replica set direct-csi-min-io-b7f886bdc to 3
```

*3. Add psp to rbac*
```
ashish@ashish:~/code/go/src/github/minio/directpv$ kubectl get pods -n direct-csi-min-io
NAME                                 READY   STATUS    RESTARTS   AGE
direct-csi-min-io-796457cbcc-9jqnh   2/2     Running   0          3m16s
direct-csi-min-io-796457cbcc-kfgl9   2/2     Running   0          3m16s
direct-csi-min-io-796457cbcc-r2987   2/2     Running   0          3m16s
direct-csi-min-io-fsvbw              3/3     Running   0          3m16s

```

Once the PSP are applied the  pods come up. There were no errors related to host path or capabilities,
Yet added these in pod security policy 
```
HostNetwork:         true,
			AllowedCapabilities: []v1.Capability{policy.AllowAllCapabilities},
			Volumes:             []policy.FSType{policy.HostPath},
```
We can disscuss whether to modify PSP or not. 

