### PR TITLE
Sort volume list by PODNAMESPACE 

### DIFF
--- a/cmd/kubectl-directpv/volumes_list.go
+++ b/cmd/kubectl-directpv/volumes_list.go
@@ -163,7 +163,13 @@ func listVolumes(ctx context.Context, args []string) error {
 		}
 		t.AppendRow(row)
 	}
-
+	t.SortBy(
+		[]table.SortBy{
+			{
+				Name: "PODNAMESPACE",
+				Mode: table.Asc,
+			},
+		})
 	t.Render()
 	return nil
 }

--- a/pkg/client/list_test.go
+++ b/pkg/client/list_test.go
@@ -79,3 +79,46 @@ func TestGetVolumeList(t *testing.T) {
 		t.Fatalf("expected: 2000, got: %v", len(volumes))
 	}
 }
+
+func TestGetSortedVolumeList(t *testing.T) {
+	SetLatestDirectCSIVolumeInterface(clientsetfake.NewSimpleClientset().DirectV1beta3().DirectCSIVolumes())
+	volumes, err := GetVolumeList(context.TODO(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 {
+		t.Fatalf("expected: 0, got: %v", len(volumes))
+	}
+
+	objects := []runtime.Object{}
+	for i := 1; i <= 4; i++ {
+		objects = append(
+			objects, &directcsi.DirectCSIVolume{ObjectMeta: metav1.ObjectMeta{Namespace: "CCC", Name: fmt.Sprintf("volume-%v", i)}},
+		)
+	}
+	for i := 5; i <= 8; i++ {
+		objects = append(
+			objects, &directcsi.DirectCSIVolume{ObjectMeta: metav1.ObjectMeta{Namespace: "BBB", Name: fmt.Sprintf("volume-%v", i)}},
+		)
+	}
+	for i := 9; i <= 12; i++ {
+		objects = append(
+			objects, &directcsi.DirectCSIVolume{ObjectMeta: metav1.ObjectMeta{Namespace: "AAA", Name: fmt.Sprintf("volume-%v", i)}},
+		)
+	}
+
+	SetLatestDirectCSIVolumeInterface(clientsetfake.NewSimpleClientset(objects...).DirectV1beta3().DirectCSIVolumes())
+	volumes, err = GetVolumeList(context.TODO(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if volumes[0].ObjectMeta.Namespace != "AAA" {
+		t.Fatalf("expected volume to be in Namespace : AAA, got: %v", volumes[0].ObjectMeta.Namespace)
+	}
+	if volumes[4].ObjectMeta.Namespace != "BBB" {
+		t.Fatalf("expected volume to be in Namespace : BBB, got: %v", volumes[3].ObjectMeta.Namespace)
+	}
+	if volumes[8].ObjectMeta.Namespace != "CCC" {
+		t.Fatalf("expected volume to be in Namespace : CCC, got: %v", volumes[7].ObjectMeta.Namespace)
+	}
+}


### PR DESCRIPTION
The table has the sort functionality defined here "github.com/jedib0t/go-pretty/v6/table". 



Refer https://github.com/jedib0t/go-pretty/blob/9c7a814efc0e7394783a7d7c1682c3ed068846f2/table/sort_test.go#L31
WRT to test case 
```
WARNING plugin `direct-csi` will be deprecated in v2.3, please use `directpv` plugin instead
 VOLUME                                    CAPACITY  NODE                   DRIVE  PODNAME  PODNAMESPACE    DRIVENAME 
 pvc-3c427caa-b43b-445c-95c7-41dcf247cb65  80 MiB    localhost.localdomain         minio-0  default                   
 pvc-0ff81d61-5ad5-4998-84b4-43fa4829c336  80 MiB    localhost.localdomain         minio-0  default                   
 pvc-4eed4302-cdad-41e8-a3c5-4f7712f33309  80 MiB    localhost.localdomain         minio-0  default                   
 pvc-eb9befb2-eaf7-4521-8a03-e931e25f1044  80 MiB    localhost.localdomain         minio-0  default                   
 pvc-7b078240-eee8-44e3-acf3-abc348db00d8  80 MiB    localhost.localdomain         minio-1  default                   
 pvc-31e92304-d11d-4e48-b541-34d9841a5b0f  80 MiB    localhost.localdomain         minio-1  default                   
 pvc-df7d3e74-b683-4ae4-95db-2063f6df66a1  80 MiB    localhost.localdomain         minio-1  default                   
 pvc-5f89c2d3-8fb6-4a29-9e1a-f6883315722f  80 MiB    localhost.localdomain         minio-1  default                   
 pvc-4eec575e-51fb-4d5d-bdde-cfea13a0aad9  80 MiB    localhost.localdomain         minio-2  default                   
 pvc-2b090bcd-caa6-417c-8604-6d549abc94ca  80 MiB    localhost.localdomain         minio-2  default                   
 pvc-cdd97c27-ebf5-4df2-b9eb-1abbef948124  80 MiB    localhost.localdomain         minio-2  default                   
 pvc-560ef5dc-3843-4fd5-b68b-29a052b08fd1  80 MiB    localhost.localdomain         minio-2  default                   
 pvc-40545eff-ab42-4c9c-bba9-a2e8889b28c3  80 MiB    localhost.localdomain         minio-3  default                   
 pvc-847741f3-2a1c-4dca-8cb9-3bd55b873415  80 MiB    localhost.localdomain         minio-3  default                   
 pvc-e3f4af62-4f73-47ab-96c2-17452a069ca0  80 MiB    localhost.localdomain         minio-3  default                   
 pvc-782bb8d7-389c-4133-9c85-da02cec972c0  80 MiB    localhost.localdomain         minio-3  default 
```