### PR TITLE
Update the mountpoint after mounting the drive on node restart

### DIFF
--- a/pkg/node/uevent_helpers.go
+++ b/pkg/node/uevent_helpers.go
@@ -193,7 +193,7 @@ func updateDriveProperties(drive *directcsi.DirectCSIDrive, device *sys.Device) 
 		updated = true
 	}
 
-	if drive.Status.Mountpoint != device.FirstMountPoint {
+	if device.FirstMountPoint != "" && drive.Status.Mountpoint != device.FirstMountPoint {
 		drive.Status.Mountpoint = device.FirstMountPoint
 		drive.Status.MountOptions = device.FirstMountOptions
 		updated = true


### PR DESCRIPTION
Currently, as the `drive.Status.Mountpoint` is left empty after mounting, the volumes will be bind mounted to the `/` dir (/pvc-XXX)

This patch will fix the volume mounts on node restarts.