### PR TITLE
Remove SerialNumber matching as it is not reliable

### DIFF
--- a/pkg/node/discovery/drive_matcher.go
+++ b/pkg/node/discovery/drive_matcher.go
@@ -40,9 +40,6 @@ func (d *Discovery) identifyDriveByAttributes(localDriveState directcsi.DirectCS
 	if selectedDrive, err := d.selectByPartitionUUID(localDriveState.PartitionUUID); err == nil {
 		return selectedDrive, nil
 	}
-	if selectedDrive, err := d.selectBySerialNumber(localDriveState.SerialNumber, localDriveState.PartitionNum); err == nil {
-		return selectedDrive, nil
-	}
 	return nil, errNoMatchFound
 }
 
@@ -67,20 +64,6 @@ func (d *Discovery) selectByPartitionUUID(partUUID string) (*remoteDrive, error)
 	}
 	for i, remoteDrive := range d.remoteDrives {
 		if !remoteDrive.matched && remoteDrive.Status.PartitionUUID == partUUID {
-			d.remoteDrives[i].matched = true
-			return d.remoteDrives[i], nil
-		}
-	}
-	return nil, errNoMatchFound
-}
-
-func (d *Discovery) selectBySerialNumber(serialNumber string, partitionNum int) (*remoteDrive, error) {
-	if serialNumber == "" {
-		// No serialNumber available to match
-		return nil, errNoMatchFound
-	}
-	for i, remoteDrive := range d.remoteDrives {
-		if !remoteDrive.matched && remoteDrive.Status.SerialNumber == serialNumber && remoteDrive.Status.PartitionNum == partitionNum {
 			d.remoteDrives[i].matched = true
 			return d.remoteDrives[i], nil
 		}

--- a/pkg/node/discovery/drive_matcher.go
+++ b/pkg/node/discovery/drive_matcher.go
@@ -40,6 +40,9 @@ func (d *Discovery) identifyDriveByAttributes(localDriveState directcsi.DirectCS
 	if selectedDrive, err := d.selectByPartitionUUID(localDriveState.PartitionUUID); err == nil {
 		return selectedDrive, nil
 	}
+	if selectedDrive, err := d.selectByWWID(localDriveState.WWID, localDriveState.PartitionNum); err == nil {
+		return selectedDrive, nil
+	}
 	return nil, errNoMatchFound
 }
 
@@ -64,6 +67,20 @@ func (d *Discovery) selectByPartitionUUID(partUUID string) (*remoteDrive, error)
 	}
 	for i, remoteDrive := range d.remoteDrives {
 		if !remoteDrive.matched && remoteDrive.Status.PartitionUUID == partUUID {
+			d.remoteDrives[i].matched = true
+			return d.remoteDrives[i], nil
+		}
+	}
+	return nil, errNoMatchFound
+}
+
+func (d *Discovery) selectByWWID(wwid string, partitionNum int) (*remoteDrive, error) {
+	if wwid == "" {
+		// No wwid available to match
+		return nil, errNoMatchFound
+	}
+	for i, remoteDrive := range d.remoteDrives {
+		if !remoteDrive.matched && remoteDrive.Status.WWID == wwid && remoteDrive.Status.PartitionNum == partitionNum {
 			d.remoteDrives[i].matched = true
 			return d.remoteDrives[i], nil
 		}


### PR DESCRIPTION
SMART info probes on HP drives will report the controller's (HPE controller) serial number
which will be same for all the drives controlled by the controller.

This may lead to wrong matching of drives during start-ups.

Also, add wwid+partitionno check while matching 