### PR TITLE
Use go1.17.8 for the build and go1.18 for the sidecar images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ GID=$(id -g)
 docker_run=( docker run -u "${UID}:${GID}" -e HOME=/go/home \
                     -v "${SCRIPT_ROOT}:/go/src/github.com/minio/directpv" \
                     -w /go/src/github.com/minio/directpv \
-                    --entrypoint hack/build-without-docker.sh golang:1.17 )
+                    --entrypoint hack/build-without-docker.sh golang:1.17.8 )
 [ -t 1 ] && docker_run+=( --interactive --tty )
 
 "${docker_run[@]}"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -100,9 +100,9 @@ After running this installation:
 
 Push the following images to your private registry
  
- - quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.17
- - quay.io/minio/csi-provisioner:v2.2.0-go1.17
- - quay.io/minio/livenessprobe:v2.2.0-go1.17
+ - quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.18
+ - quay.io/minio/csi-provisioner:v2.2.0-go1.18
+ - quay.io/minio/livenessprobe:v2.2.0-go1.18
  - quay.io/minio/directpv:${latest_tag_name}
 
 Here is a shell script to Copy-Paste into your terminal to do the above steps:
@@ -112,9 +112,9 @@ Here is a shell script to Copy-Paste into your terminal to do the above steps:
 # set this to private registry URL (the URL should NOT include http or https)
 if [ -z $PRIVATE_REGISTRY_URL ]; then "PRIVATE_REGISTRY_URL env var should be set"; fi
 
-images[0]=quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.17
-images[1]=quay.io/minio/csi-provisioner:v2.2.0-go1.17
-images[2]=quay.io/minio/livenessprobe:v2.2.0-go1.17
+images[0]=quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.18
+images[1]=quay.io/minio/csi-provisioner:v2.2.0-go1.18
+images[2]=quay.io/minio/livenessprobe:v2.2.0-go1.18
 images[3]=quay.io/minio/directpv:$(curl -s "https://api.github.com/repos/minio/directpv/releases/latest" | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/')
 
 function privatize(){ echo $1 | sed "s#quay.io#${PRIVATE_REGISTRY_URL}#g"; }

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -14,3 +14,17 @@ The following recording demonstrates the version upgrade path.
 [![asciicast](https://asciinema.org/a/2Stv8ugsQg72rWOEWlLUVNWrV.svg)](https://asciinema.org/a/2Stv8ugsQg72rWOEWlLUVNWrV)
 
 NOTE: For the users who don't prefer krew, Please find the latest images in [releases](https://github.com/minio/directpv/releases).
+
+#### Upgrade from v1.4.3 to latest
+
+If the existing version is v1.4.3, please upgrade to v1.4.6 and then to the latest.
+
+#### Upgrade to v3.0.0
+
+in v3.0.0, the csi sidecar images have been updated. If private registry is used for images, please make sure the following images are available in your registry before upgrade.
+
+```
+quay.io/minio/csi-provisioner:v2.2.0-go1.18
+quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.18
+quay.io/minio/livenessprobe:v2.2.0-go1.18
+```

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/jedib0t/go-pretty/v6 v6.0.5
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,6 @@ github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMW
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/installer/config.go
+++ b/pkg/installer/config.go
@@ -29,14 +29,14 @@ import (
 
 // CSI provisioner images
 const (
-	// quay.io/minio/csi-provisioner:v2.2.0-go1.17
-	CSIImageCSIProvisioner = "csi-provisioner@sha256:d4f94539565cf62aea57062b6a42c5156337003133fd3f51b93df9a789e69840"
+	// quay.io/minio/csi-provisioner:v2.2.0-go1.18
+	CSIImageCSIProvisioner = "csi-provisioner@sha256:c185db49ba02c384633165894147f8d7041b34b173e82a49d7145e50e809b8d6"
 
-	// quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.17
-	CSIImageNodeDriverRegistrar = "csi-node-driver-registrar@sha256:843fb23b1a3fa1de986378b0b8c08c35f8e62499d386de8ec57801fd029afe6d"
+	// quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.18
+	CSIImageNodeDriverRegistrar = "csi-node-driver-registrar@sha256:d46524376ffccf2c29f2fb373a67faa0d14a875ae01380fa148b4c5a8d47a6c6"
 
-	// quay.io/minio/livenessprobe:v2.2.0-go1.17
-	CSIImageLivenessProbe = "livenessprobe@sha256:928a80be4d363e0e438ff28dcdb00d8d674d3059c6149a8cda64ce6016a9a3f8"
+	// quay.io/minio/livenessprobe:v2.2.0-go1.18
+	CSIImageLivenessProbe = "livenessprobe@sha256:a3a5f8e046ece910505a7f9529c615547b1152c661f34a64b13ac7d9e13df4a7"
 )
 
 func defaultIfZeroString(left, right string) string {


### PR DESCRIPTION
- the sidecar images are compiled and pushed with go1.18
- the upgrade docs are updated