### PR TITLE
Implement volume health monitor

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Documentation
  - [Metrics](./metrics.md)
  - [Troubleshooting](./troubleshooting.md)
  - [Drive States](./drive-states.md)
+ - [Volume Health Monitor](./volume-health-monitor.md)
 
 <!--- 
  - [Usage Guide](./usage-guide.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -195,3 +195,19 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
 (Note: Also verify if the systemd-udevd services are running on the host)
+
+### Volume mount errors
+
+If the respective volume mounts are gone or accidentally umounted, you may see events in corresponding pods and PVCs(If external health monitor is deployed) indicating that the volume mounts weren't mounted properly.
+
+For example,
+
+```log
+Warning  VolumeConditionAbnormal  46s (x13 over 19m)  kubelet            Volume minio-data-1: container path is not mounted
+```
+
+```log
+  Warning  VolumeConditionAbnormal  29s                csi-pv-monitor-controller-direct-csi-min-io                                                staging path is not mounted
+```
+
+In such cases, restarting the corresponding pods may re-create the missing volume mounts.

--- a/docs/volume-health-monitor.md
+++ b/docs/volume-health-monitor.md
@@ -1,0 +1,129 @@
+
+Volume Health Monitor
+-------------
+
+This is a CSI feature introduced as an Alpha feature in Kubernetes v1.19 and a second Alpha was done in v1.21. This feature is to detect "abnormal" volume conditions and report them as events on PVCs and Pods. A DirectPV volume will be considered as "abnormal" if the respective volume mounts are not present.
+
+Feature gate `CSIVolumeHealth` needs to be enabled for the node side monitoring to take effect.
+
+### Enable volume health monitoring
+
+Apply the following manifests to enable volume monitoring for the DirectPV volumes
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-external-health-monitor-controller
+  # replace with non-default namespace name
+  namespace: default
+
+---
+# Health monitor controller must be able to work with PVs, PVCs, Nodes and Pods
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-health-monitor-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-external-health-monitor-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-external-health-monitor-controller
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: external-health-monitor-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Health monitor controller must be able to work with configmaps or leases in the current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: external-health-monitor-controller-cfg
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-external-health-monitor-controller-role-cfg
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: csi-external-health-monitor-controller
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: external-health-monitor-controller-cfg
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-external-health-monitor-controller
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      external-health-monitor-controller: directpv-health-monitor
+  template:
+    metadata:
+      labels:
+        external-health-monitor-controller: directpv-health-monitor
+    spec:
+      serviceAccount: csi-external-health-monitor-controller
+      containers:
+        - name: csi-external-health-monitor-controller
+          image: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+          imagePullPolicy: Always
+          args:
+            - "--v=5"
+            - "--csi-address=unix:///csi/csi.sock"
+            - "--leader-election"
+            - "--http-endpoint=:8080"
+          volumeMounts:
+          - mountPath: /csi
+            mountPropagation: None
+            name: socket-dir
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/direct-csi-min-io-controller
+          type: DirectoryOrCreate
+        name: socket-dir
+```
+
+### References
+ - [External health monitor](https://github.com/kubernetes-csi/external-health-monitor)
+ - [Volume health monitoring](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring)

--- a/functests/common.sh
+++ b/functests/common.sh
@@ -240,7 +240,7 @@ function uninstall_minio() {
             break
         fi
         echo "$ME: error: ${count} provisioned volumes still exist"
-        sleep 3
+        sleep "${count}"
     done
 
     # Show output for manual debugging.
@@ -251,11 +251,8 @@ function uninstall_minio() {
         if [[ $count -eq 0 ]]; then
             break
         fi
-        # Show output for manual debugging.
-        "${DIRECT_CSI_CLIENT}" drives ls -o wide --all
-        "${DIRECT_CSI_CLIENT}" volumes ls --all -o wide
         echo "$ME: waiting for ${count} drives to be released"
-        sleep 5
+        sleep "${count}"
     done
 }
 

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -144,6 +145,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
@@ -206,6 +208,7 @@ github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5F
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -289,6 +292,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
@@ -435,6 +439,7 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -443,12 +448,18 @@ github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -706,6 +717,7 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -791,6 +803,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -886,12 +899,14 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1077,6 +1092,7 @@ k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -1096,6 +1112,7 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
+sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=

--- a/pkg/apis/direct.csi.min.io/v1beta4/types.go
+++ b/pkg/apis/direct.csi.min.io/v1beta4/types.go
@@ -325,6 +325,9 @@ const (
 
 	// DirectCSIVolumeConditionReady denotes "Ready" volume condition.
 	DirectCSIVolumeConditionReady DirectCSIVolumeCondition = "Ready"
+
+	// DirectCSIVolumeConditionAbnormal denotes "Ready" volume condition.
+	DirectCSIVolumeConditionAbnormal DirectCSIVolumeCondition = "Abnormal"
 )
 
 // DirectCSIVolumeReason denotes volume reason.
@@ -345,6 +348,15 @@ const (
 
 	// DirectCSIVolumeReasonDriveLost denotes "DriveLost" volume reason.
 	DirectCSIVolumeReasonDriveLost DirectCSIVolumeReason = "DriveLost"
+
+	// DirectCSIVolumeReasonStagingPathNotMounted denotes missing staging path mount.
+	DirectCSIVolumeReasonStagingPathNotMounted DirectCSIVolumeReason = "StagingPathNotMounted"
+
+	// DirectCSIVolumeReasonContainerPathNotMounted denotes missing container path mount.
+	DirectCSIVolumeReasonContainerPathNotMounted DirectCSIVolumeReason = "ContainerPathNotMounted"
+
+	// DirectCSIVolumeReasonNormal denotes that the volume is normal.
+	DirectCSIVolumeReasonNormal DirectCSIVolumeReason = "Normal"
 )
 
 // DirectCSIVolumeMessage denotes drive message.

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -389,6 +389,10 @@ request:
 	if !utils.IsCondition(directCSIVolume.Status.Conditions, string(directv1beta4.DirectCSIVolumeConditionReady), metav1.ConditionTrue, string(directv1beta4.DirectCSIVolumeReasonReady), "") {
 		t.Errorf("unexpected status.conditions = %v", directCSIVolume.Status.Conditions)
 	}
+
+	if !utils.IsCondition(directCSIVolume.Status.Conditions, string(directv1beta4.DirectCSIVolumeConditionAbnormal), metav1.ConditionFalse, string(directv1beta4.DirectCSIVolumeReasonNormal), "") {
+		t.Errorf("unexpected status.conditions = %v", directCSIVolume.Status.Conditions)
+	}
 }
 
 func TestV1beta1ToV1beta2DriveUpgrade(t *testing.T) {

--- a/pkg/converter/volume_upgrade.go
+++ b/pkg/converter/volume_upgrade.go
@@ -215,6 +215,15 @@ func volumeUpgradeV1Beta3ToV1Beta4(unstructured *unstructured.Unstructured) erro
 		utils.CreatedByLabelKey: utils.DirectCSIControllerName,
 	})
 
+	abnormalCondition := metav1.Condition{
+		Type:               string(directv1beta4.DirectCSIVolumeConditionAbnormal),
+		Status:             metav1.ConditionFalse,
+		Message:            "",
+		Reason:             string(directv1beta4.DirectCSIVolumeReasonNormal),
+		LastTransitionTime: metav1.Now(),
+	}
+	v1beta4DirectCSIVolume.Status.Conditions = append(v1beta4DirectCSIVolume.Status.Conditions, abnormalCondition)
+
 	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&v1beta4DirectCSIVolume)
 	if err != nil {
 		return err

--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -107,7 +107,7 @@ func (handler *driveEventHandler) ObjectType() runtime.Object {
 
 func (handler *driveEventHandler) Handle(ctx context.Context, args listener.EventArgs) error {
 	switch args.Event {
-	case listener.AddEvent, listener.UpdateEvent:
+	case listener.AddEvent, listener.UpdateEvent, listener.SyncEvent:
 		return handler.handleUpdate(ctx, args.Object.(*directcsi.DirectCSIDrive))
 	case listener.DeleteEvent:
 		return handler.delete(ctx, args.Object.(*directcsi.DirectCSIDrive))

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -88,6 +88,7 @@ const (
 	AddEvent EventType = iota + 1
 	UpdateEvent
 	DeleteEvent
+	SyncEvent
 )
 
 func (et EventType) String() string {
@@ -98,6 +99,8 @@ func (et EventType) String() string {
 		return "Update"
 	case DeleteEvent:
 		return "Delete"
+	case SyncEvent:
+		return "Sync"
 	}
 	return ""
 }
@@ -212,7 +215,7 @@ func (listener *Listener) processNextItem(ctx context.Context) bool {
 		if err := listener.indexer.Add(args.Object); err != nil {
 			klog.Error(err)
 		}
-	case UpdateEvent:
+	case UpdateEvent, SyncEvent:
 		if err := listener.indexer.Update(args.Object); err != nil {
 			klog.Error(err)
 		}
@@ -246,6 +249,14 @@ func (listener *Listener) controllerLoop(ctx context.Context) {
 		}
 
 		if oldObject, exists, err := listener.indexer.Get(delta.Object); err == nil && exists {
+			if delta.Type == cache.Sync {
+				return &EventArgs{
+					Event:     SyncEvent,
+					Key:       key,
+					Object:    delta.Object,
+					OldObject: oldObject,
+				}
+			}
 			return &EventArgs{
 				Event:     UpdateEvent,
 				Key:       key,
@@ -283,7 +294,7 @@ func (listener *Listener) controllerLoop(ctx context.Context) {
 			if args.Event == AddEvent {
 				value, loaded := listener.eventMap.LoadOrStore(uuid, *args)
 				// If add event args is not stored, error out if existing args is update event.
-				if loaded && value.(EventArgs).Event == UpdateEvent {
+				if loaded && (value.(EventArgs).Event == UpdateEvent || value.(EventArgs).Event == SyncEvent) {
 					return fmt.Errorf("cannot add already added object: %s", key)
 				}
 			} else {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,251 @@
+// This file is part of MinIO DirectPV
+// Copyright (c) 2021, 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
+	fakedirect "github.com/minio/directpv/pkg/clientset/fake"
+	"github.com/minio/directpv/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestNodeGetVolumeStats(t *testing.T) {
+	testObjects := []runtime.Object{
+		&directcsi.DirectCSIDrive{
+			TypeMeta: utils.DirectCSIDriveTypeMeta(),
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-drive",
+			},
+		},
+		&directcsi.DirectCSIVolume{
+			TypeMeta: utils.DirectCSIVolumeTypeMeta(),
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-volume-1",
+			},
+			Status: directcsi.DirectCSIVolumeStatus{
+				Drive:         "test-drive",
+				ContainerPath: "/unknown/mnt",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionStaged),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionPublished),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionReady),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonReady),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionAbnormal),
+						Status:             metav1.ConditionFalse,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonNormal),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		},
+		&directcsi.DirectCSIVolume{
+			TypeMeta: utils.DirectCSIVolumeTypeMeta(),
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-volume-2",
+			},
+			Status: directcsi.DirectCSIVolumeStatus{
+				Drive:         "test-drive",
+				ContainerPath: "/unknown/mnt",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionStaged),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionPublished),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionReady),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonReady),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionAbnormal),
+						Status:             metav1.ConditionTrue,
+						Message:            "path /unknown/mnt is not mounted",
+						Reason:             string(directcsi.DirectCSIVolumeReasonContainerPathNotMounted),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		request          *csi.NodeGetVolumeStatsRequest
+		expectedResponse *csi.NodeGetVolumeStatsResponse
+	}{
+		{
+			request: &csi.NodeGetVolumeStatsRequest{
+				VolumeId:   "test-volume-1",
+				VolumePath: "/unknown/mnt",
+			},
+			expectedResponse: &csi.NodeGetVolumeStatsResponse{
+				Usage: []*csi.VolumeUsage{
+					{
+						Unit: csi.VolumeUsage_BYTES,
+					},
+				},
+				VolumeCondition: &csi.VolumeCondition{
+					Abnormal: false,
+					Message:  "",
+				},
+			},
+		},
+		{
+			request: &csi.NodeGetVolumeStatsRequest{
+				VolumeId:   "test-volume-2",
+				VolumePath: "/unknown/mnt",
+			},
+			expectedResponse: &csi.NodeGetVolumeStatsResponse{
+				Usage: []*csi.VolumeUsage{
+					{},
+				},
+				VolumeCondition: &csi.VolumeCondition{
+					Abnormal: true,
+					Message:  "path /unknown/mnt is not mounted",
+				},
+			},
+		},
+	}
+	nodeServer := createFakeNodeServer()
+	nodeServer.directcsiClient = fakedirect.NewSimpleClientset(testObjects...)
+	ctx := context.TODO()
+	for i, testCase := range testCases {
+		response, err := nodeServer.NodeGetVolumeStats(ctx, testCase.request)
+		if err != nil {
+			t.Fatalf("case %v: unexpected error %v", i+1, err)
+		}
+		if !reflect.DeepEqual(response, testCase.expectedResponse) {
+			t.Fatalf("case %v: expected: %#+v, got: %#+v\n", i+1, testCase.expectedResponse, response)
+		}
+		if response.GetVolumeCondition().GetAbnormal() {
+			volObj, gErr := nodeServer.directcsiClient.DirectV1beta4().DirectCSIVolumes().Get(ctx, testCase.request.GetVolumeId(), metav1.GetOptions{
+				TypeMeta: utils.DirectCSIVolumeTypeMeta(),
+			})
+			if gErr != nil {
+				t.Fatalf("case %v: volume (%s) not found. Error: %v", i+1, testCase.request.GetVolumeId(), gErr)
+			}
+			if !utils.IsCondition(volObj.Status.Conditions,
+				string(directcsi.DirectCSIVolumeConditionAbnormal),
+				metav1.ConditionTrue,
+				string(directcsi.DirectCSIVolumeReasonContainerPathNotMounted),
+				response.GetVolumeCondition().GetMessage()) {
+				t.Fatalf("case: %v: abnormal condition is not set to True for abnormal volumes. volume: %v", i+1, testCase.request.GetVolumeId())
+			}
+		}
+	}
+}
+
+func TestNodeGetCapabilities(t *testing.T) {
+	result, err := createFakeNodeServer().NodeGetCapabilities(context.TODO(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedResult := &csi.NodeGetCapabilitiesResponse{
+		Capabilities: []*csi.NodeServiceCapability{
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+					},
+				},
+			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+					},
+				},
+			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Fatalf("expected: %#+v, got: %#+v\n", expectedResult, result)
+	}
+}
+
+func TestNodeGetInfo(t *testing.T) {
+	ns := createFakeNodeServer()
+	result, err := createFakeNodeServer().NodeGetInfo(context.TODO(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedResult := &csi.NodeGetInfoResponse{
+		NodeId:            ns.NodeID,
+		MaxVolumesPerNode: int64(100),
+		AccessibleTopology: &csi.Topology{
+			Segments: map[string]string{
+				string(utils.TopologyDriverIdentity): ns.Identity,
+				string(utils.TopologyDriverRack):     ns.Rack,
+				string(utils.TopologyDriverZone):     ns.Zone,
+				string(utils.TopologyDriverRegion):   ns.Region,
+				string(utils.TopologyDriverNode):     ns.NodeID,
+			},
+		},
+	}
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Fatalf("expected: %#+v, got: %#+v\n", expectedResult, result)
+	}
+}
+
+func TestNodeExpandVolume(t *testing.T) {
+	if _, err := createFakeNodeServer().NodeExpandVolume(context.TODO(), nil); err == nil {
+		t.Fatal("error expected")
+	}
+}

--- a/pkg/node/publish_unpublish.go
+++ b/pkg/node/publish_unpublish.go
@@ -142,6 +142,13 @@ func (n *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			conditions[i].Status = utils.BoolToCondition(true)
 			conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonInUse)
 		}
+		if c.Type == string(directcsi.DirectCSIVolumeConditionAbnormal) {
+			if c.Reason == string(directcsi.DirectCSIVolumeReasonContainerPathNotMounted) {
+				conditions[i].Status = utils.BoolToCondition(false)
+				conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNormal)
+				conditions[i].Message = ""
+			}
+		}
 	}
 	vol.Status.ContainerPath = req.GetTargetPath()
 
@@ -194,6 +201,12 @@ func (n *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 			conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNotInUse)
 		case string(directcsi.DirectCSIVolumeConditionStaged):
 		case string(directcsi.DirectCSIVolumeConditionReady):
+		case string(directcsi.DirectCSIVolumeConditionAbnormal):
+			if c.Reason == string(directcsi.DirectCSIVolumeReasonContainerPathNotMounted) {
+				conditions[i].Status = utils.BoolToCondition(false)
+				conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNormal)
+				conditions[i].Message = ""
+			}
 		}
 	}
 	vol.Status.ContainerPath = ""

--- a/pkg/node/stage_unstage.go
+++ b/pkg/node/stage_unstage.go
@@ -109,6 +109,12 @@ func (n *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		case string(directcsi.DirectCSIVolumeConditionStaged):
 			conditions[i].Status = utils.BoolToCondition(true)
 			conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonInUse)
+		case string(directcsi.DirectCSIVolumeConditionAbnormal):
+			if c.Reason == string(directcsi.DirectCSIVolumeReasonStagingPathNotMounted) {
+				conditions[i].Status = utils.BoolToCondition(false)
+				conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNormal)
+				conditions[i].Message = ""
+			}
 		}
 	}
 
@@ -166,6 +172,12 @@ func (n *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 		case string(directcsi.DirectCSIVolumeConditionReady):
 			conditions[i].Status = utils.BoolToCondition(false)
 			conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNotReady)
+		case string(directcsi.DirectCSIVolumeConditionAbnormal):
+			if c.Reason == string(directcsi.DirectCSIVolumeReasonStagingPathNotMounted) {
+				conditions[i].Status = utils.BoolToCondition(false)
+				conditions[i].Reason = string(directcsi.DirectCSIVolumeReasonNormal)
+				conditions[i].Message = ""
+			}
 		}
 	}
 


### PR DESCRIPTION
- Implement ListVolumes and GetVolume controller RPCs
- Introduce a new volume status condition - Abnormal to denote an abnormal volume
- refer: https://github.com/kubernetes-csi/external-health-monitor

Steps to test :

- Start minikube with `CSIVolumeHealth=true` feature gate enabled - `minikube start --memory 12000 --kubernetes-version=v1.21.6 --feature-gates=CSIVolumeHealth=true --driver=none`
- Apply the following manifest for external health monitor

rbac :-

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: csi-external-health-monitor-controller
  # replace with non-default namespace name
  namespace: default

---
# Health monitor controller must be able to work with PVs, PVCs, Nodes and Pods
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: external-health-monitor-controller-runner
rules:
  - apiGroups: [""]
    resources: ["persistentvolumes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["get", "list", "watch", "create", "patch"]

---
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: csi-external-health-monitor-controller-role
subjects:
  - kind: ServiceAccount
    name: csi-external-health-monitor-controller
    # replace with non-default namespace name
    namespace: default
roleRef:
  kind: ClusterRole
  name: external-health-monitor-controller-runner
  apiGroup: rbac.authorization.k8s.io

---
# Health monitor controller must be able to work with configmaps or leases in the current namespace
# if (and only if) leadership election is enabled
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  # replace with non-default namespace name
  namespace: default
  name: external-health-monitor-controller-cfg
rules:
- apiGroups: ["coordination.k8s.io"]
  resources: ["leases"]
  verbs: ["get", "watch", "list", "delete", "update", "create"]

---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: csi-external-health-monitor-controller-role-cfg
  # replace with non-default namespace name
  namespace: default
subjects:
  - kind: ServiceAccount
    name: csi-external-health-monitor-controller
    # replace with non-default namespace name
    namespace: default
roleRef:
  kind: Role
  name: external-health-monitor-controller-cfg
  apiGroup: rbac.authorization.k8s.io

```

Deployment :-

```yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: csi-external-health-monitor-controller
spec:
  replicas: 3
  selector:
    matchLabels:
      external-health-monitor-controller: directpv-health-monitor
  template:
    metadata:
      labels:
        external-health-monitor-controller: directpv-health-monitor
    spec:
      serviceAccount: csi-external-health-monitor-controller
      containers:
        - name: csi-external-health-monitor-controller
          image: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
          imagePullPolicy: Always
          args:
            - "--v=5"
            - "--csi-address=unix:///csi/csi.sock"
            - "--leader-election"
            - "--http-endpoint=:8080"
          volumeMounts:
          - mountPath: /csi
            mountPropagation: None
            name: socket-dir
      volumes:
      - hostPath:
          path: /var/lib/kubelet/plugins/direct-csi-min-io-controller
          type: DirectoryOrCreate
        name: socket-dir
```

- Install directpv and deploy MinIO after formatting the drives
- Pick a PVC of any of the pod
```
kubectl-directpv volumes ls --pod-name minio-0
```
- Get the ContainerPath or StagingPath of the volume - `kubectl get directcsivolume <PVC> -o yaml` and get the staging/container path
- Umount the staging or container path - `sudo umount <path>`
- Wait for a min and check the corresponding pod and PVC description. you should see  an event indicating the missing staging or container path. 