### PR TITLE
Skip SMART info probes for reading serial number of the drive

### DIFF
--- a/pkg/sys/drive_discovery_linux.go
+++ b/pkg/sys/drive_discovery_linux.go
@@ -33,7 +33,6 @@ import (
 	"github.com/minio/directpv/pkg/fs"
 	fserrors "github.com/minio/directpv/pkg/fs/errors"
 	"github.com/minio/directpv/pkg/mount"
-	"github.com/minio/directpv/pkg/sys/smart"
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 )
@@ -110,11 +109,6 @@ func getRemovable(name string) (bool, error) {
 func getReadOnly(name string) (bool, error) {
 	s, err := readFirstLine("/sys/class/block/"+name+"/ro", false)
 	return s != "" && s != "0", err
-}
-
-func getSerial(name string) (string, error) {
-	serial, _ := smart.GetSerialNumber("/dev/" + name)
-	return serial, nil
 }
 
 func getHidden(name string) bool {
@@ -341,10 +335,6 @@ func (device *Device) ProbeSysInfo() (err error) {
 
 // ProbeDevInfo probes device information from /dev
 func (device *Device) ProbeDevInfo() (err error) {
-	if device.Serial, err = getSerial(device.Name); err != nil {
-		return err
-	}
-
 	// No FS information needed for hidden devices
 	if !device.Hidden {
 		CDROMs, err := getCDROMs()

--- a/pkg/uevent/match.go
+++ b/pkg/uevent/match.go
@@ -56,7 +56,6 @@ var stageOneMatchers = []matchFn{
 	ueventFSUUIDMatcher,
 	// v1beta2 matchers
 	fsUUIDMatcher,
-	serialNumberMatcher,
 	// size matchers
 	totalCapacityMatcher,
 }
@@ -283,10 +282,6 @@ func ueventFSUUIDMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (b
 
 func fsUUIDMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {
 	return mutablePropertyMatcher(device.FSUUID, drive.Status.FilesystemUUID)
-}
-
-func serialNumberMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {
-	return mutablePropertyMatcher(device.Serial, drive.Status.SerialNumber)
 }
 
 func fileSystemTypeMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {

--- a/pkg/uevent/match_test.go
+++ b/pkg/uevent/match_test.go
@@ -291,40 +291,6 @@ func TestMDUUIDMatcher(t *testing.T) {
 	}
 }
 
-func TestSerialNumberMatcher(t *testing.T) {
-	case1Drive := directcsi.DirectCSIDrive{Status: directcsi.DirectCSIDriveStatus{SerialNumber: ""}}
-	case2Drive := directcsi.DirectCSIDrive{Status: directcsi.DirectCSIDriveStatus{SerialNumber: "31IF73XDFDM3"}}
-	case3Drive := directcsi.DirectCSIDrive{Status: directcsi.DirectCSIDriveStatus{SerialNumber: "different-31IF73XDFDM3"}}
-	case1Device := &sys.Device{Serial: ""}
-	case2Device := &sys.Device{Serial: "31IF73XDFDM3"}
-	testCases := []struct {
-		device   *sys.Device
-		drive    *directcsi.DirectCSIDrive
-		match    bool
-		consider bool
-		err      error
-	}{
-		// SerialNumber blank in both
-		{case1Device, &case1Drive, false, true, nil},
-		// SerialNumber blank in device
-		{case1Device, &case2Drive, false, true, nil},
-		// SerialNumber blank in drive
-		{case2Device, &case1Drive, false, true, nil},
-		// SerialNumber not blank in both and match
-		{case2Device, &case2Drive, true, false, nil},
-		// SerialNumber not blank in both and does not match
-		{case2Device, &case3Drive, false, true, nil},
-	}
-
-	for i, testCase := range testCases {
-		match, consider, err := serialNumberMatcher(testCase.device, testCase.drive)
-		if match != testCase.match || consider != testCase.consider || err != testCase.err {
-			t.Fatalf("case %v: expected: match %v , consider %v , error %v ; got: match %v  consider %v  error %v ",
-				i+1, testCase.match, testCase.consider, testCase.err, match, consider, err)
-		}
-	}
-}
-
 func TestUeventFSUUIDMatcher(t *testing.T) {
 	case1Drive := directcsi.DirectCSIDrive{Status: directcsi.DirectCSIDriveStatus{UeventFSUUID: ""}}
 	case2Drive := directcsi.DirectCSIDrive{Status: directcsi.DirectCSIDriveStatus{UeventFSUUID: "ueventfsuuid"}}


### PR DESCRIPTION
We perform IOCTL calls to read the smart info serial number of the drive. As a side-effect,
this backfires with too many CHANGE udev events

This PR removes the smart info probe as we already have serial numbers read from udev data.

Fixes #583