### PR TITLE
Honour SYSTEMD_READY udev data value

### DIFF
--- a/functests/tests.sh
+++ b/functests/tests.sh
@@ -147,6 +147,8 @@ echo "$ME: Setup environment"
 setup_lvm
 setup_luks
 
+sleep 30
+
 echo "$ME: Run build test"
 test_build
 

--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -135,6 +135,10 @@ func (handler *driveEventHandler) handleUpdate(ctx context.Context, drive *direc
 			return nil
 		}
 		return handler.mountDrive(ctx, drive, true)
+	case errDriveNotReady:
+		// We don't know when the drive will be ready
+		// returning nil to skip exponential retries
+		return nil
 	default:
 		if os.IsNotExist(err) {
 			return handler.lost(ctx, drive)

--- a/pkg/drive/utils.go
+++ b/pkg/drive/utils.go
@@ -34,6 +34,7 @@ import (
 var (
 	errDriveValueMismatch = errors.New("drive value mismatch")
 	errDriveNotUpgraded   = errors.New("drive not upgraded")
+	errDriveNotReady      = errors.New("drive is not ready")
 )
 
 func getDevice(major, minor uint32) (string, error) {
@@ -90,6 +91,10 @@ func VerifyHostStateForDrive(drive *directcsi.DirectCSIDrive) error {
 	if err != nil {
 		return err
 	}
+	if runUdevData.NotReady {
+		return errDriveNotReady
+	}
+
 	device := &sys.Device{
 		Name:         filepath.Base(drive.Status.Path),
 		Major:        int(drive.Status.MajorNumber),

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -40,6 +40,8 @@ type UDevData struct {
 	FSUUID           string
 	PCIPath          string
 	UeventSerialLong string
+	// internal
+	NotReady bool
 }
 
 // Device is a block device information.

--- a/pkg/sys/udev_linux.go
+++ b/pkg/sys/udev_linux.go
@@ -82,6 +82,13 @@ func MapToUdevData(eventMap map[string]string) (*UDevData, error) {
 		}
 	}
 
+	var notReady bool
+	if value, found := eventMap["SYSTEMD_READY"]; found {
+		// If set to "0", the device seems to be unplugged or in un-intialized state
+		// reference: https://www.freedesktop.org/software/systemd/man/systemd.device.html
+		notReady = value == "0"
+	}
+
 	return &UDevData{
 		Partition:        partition,
 		WWID:             eventMap["ID_WWN"],
@@ -98,5 +105,6 @@ func MapToUdevData(eventMap map[string]string) (*UDevData, error) {
 		FSType:           eventMap["ID_FS_TYPE"],
 		UeventSerialLong: eventMap["ID_SERIAL"],
 		PCIPath:          eventMap["ID_PATH"],
+		NotReady:         notReady,
 	}, nil
 }


### PR DESCRIPTION
If this value is set to "0", then device seems to be unplugged or not initialized yet.
This uninitialized state will initially show up after which a "changed" event will be generated after the device is fully setup.

reference: https://www.freedesktop.org/software/systemd/man/systemd.device.html

```
SYSTEMD_READY=

    If set to 0, systemd will consider this device unplugged even if it shows up in the udev tree. If this property is unset or set to 1, the device will be considered plugged if it is visible in the udev tree.

    This option is useful for devices that initially show up in an uninitialized state in the tree, and for which a "changed" event is generated the moment they are fully set up. Note that SYSTEMD_WANTS= (see above) is not acted on as long as SYSTEMD_READY=0 is set for a device.
```