### PR TITLE
Minor fixes in partitionUUID and FSType matcher functions

### DIFF
--- a/pkg/node/uevent_utils.go
+++ b/pkg/node/uevent_utils.go
@@ -88,7 +88,13 @@ func (d *driveEventHandler) setDriveStatus(device *sys.Device, drive *directcsi.
 	// fill hwinfo only if it is empty
 	if updatedDrive.Status.PartitionUUID == "" {
 		updatedDrive.Status.PartitionUUID = device.PartUUID
+	} else {
+		// PartitionUUID values in versions < 3.0.0 is upper-cased
+		if strings.EqualFold(updatedDrive.Status.PartitionUUID, device.PartUUID) {
+			updatedDrive.Status.PartitionUUID = device.PartUUID
+		}
 	}
+
 	if updatedDrive.Status.DMUUID == "" {
 		updatedDrive.Status.DMUUID = device.DMUUID
 	}

--- a/pkg/uevent/match.go
+++ b/pkg/uevent/match.go
@@ -227,7 +227,7 @@ func vendorMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, b
 }
 
 func partitionUUIDMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {
-	return immutablePropertyMatcher(device.PartUUID, drive.Status.PartitionUUID)
+	return immutablePropertyMatcher(strings.ToLower(device.PartUUID), strings.ToLower(drive.Status.PartitionUUID))
 }
 
 func dmUUIDMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {
@@ -285,6 +285,11 @@ func fsUUIDMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, b
 }
 
 func fileSystemTypeMatcher(device *sys.Device, drive *directcsi.DirectCSIDrive) (bool, bool, error) {
+	// udev probe reports "vfat" as the fstype for fat32 drives
+	// whereas fat32 probes for versions < v3.0.0 reported "fat32"
+	if device.FSType == "vfat" && drive.Status.Filesystem == "fat32" {
+		return true, false, nil
+	}
 	return mutablePropertyMatcher(device.FSType, drive.Status.Filesystem)
 }
 


### PR DESCRIPTION
- Partition probe in versions < 2.0.0 had upper-cased partitionUUID, this PR fixes the
  partition matcher function to be case-insensitive.
- Fat32 fs probe in versions < 3.0.0 had fstype to be "fat32", in versions > v3.0.0, the udev probe
  reported fat32 fstype to be "vfat". Fixed the fstype matcher function to consider such checks.