### PR TITLE
Implement `kubectl directpv drives purge` command to purge the lost|detached drives

### DIFF
--- a/cmd/kubectl-directpv/drives.go
+++ b/cmd/kubectl-directpv/drives.go
@@ -60,4 +60,5 @@ func init() {
 	drivesCmd.AddCommand(drivesAccessTierCmd)
 	drivesCmd.AddCommand(releaseDrivesCmd)
 	drivesCmd.AddCommand(unreleaseDrivesCmd)
+	drivesCmd.AddCommand(purgeDrivesCmd)
 }

--- a/cmd/kubectl-directpv/drives_purge.go
+++ b/cmd/kubectl-directpv/drives_purge.go
@@ -1,0 +1,149 @@
+// This file is part of MinIO DirectPV
+// Copyright (c) 2021, 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
+	"github.com/minio/directpv/pkg/client"
+	"github.com/minio/directpv/pkg/utils"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/klog/v2"
+)
+
+var purgeDrivesCmd = &cobra.Command{
+	Use:   "purge",
+	Short: utils.BinaryNameTransform("purge detached|lost drives in the {{ . }} cluster"),
+	Long:  "",
+	Example: utils.BinaryNameTransform(`
+# Purge all drives in the cluster
+$ kubectl {{ . }} drives purge --all
+
+# Purge 'sdf' drives in all nodes
+$ kubectl {{ . }} drives purge --drives '/dev/sdf'
+
+# Purge the lost drives using ellipses notation for drive paths
+$ kubectl {{ . }} drives purge --drives '/dev/sd{a...z}'
+
+# Purge the lost drives from selective nodes using ellipses notation for node names
+$ kubectl {{ . }} drives purge --nodes 'direct-{1...3}'
+
+# Purge all lost drives from a particular node
+$ kubectl {{ . }} drives purge --nodes=direct-1
+
+# Purge all lost drives based on the access-tier set [hot|cold|warm]
+$ kubectl {{ . }} drives purge --access-tier=hot
+
+# Combine multiple parameters using multi-arg
+$ kubectl {{ . }} drives purge --nodes=direct-1 --nodes=othernode-2
+
+# Combine multiple parameters using csv
+$ kubectl {{ . }} drives purge --nodes=direct-1,othernode-2
+
+# Combine multiple parameters using ellipses notations
+$ kubectl {{ . }} drives purge --nodes "direct-{3...4}" --drives "/dev/xvd{b...f}"
+
+# Purge a lost drive by it's drive-id
+$ kubectl {{ . }} drives purge <drive_id>
+
+# Purge more than one lost drives by their drive-ids
+$ kubectl {{ . }} drives purge <drive_id_1> <drive_id_2>
+`),
+	RunE: func(c *cobra.Command, args []string) error {
+		if !all {
+			if len(drives) == 0 && len(nodes) == 0 && len(accessTiers) == 0 && len(args) == 0 {
+				return fmt.Errorf("atleast one of '%s', '%s' or '%s' must be specified",
+					utils.Bold("--all"),
+					utils.Bold("--drives"),
+					utils.Bold("--nodes"))
+			}
+		}
+		if err := validateDriveSelectors(); err != nil {
+			return err
+		}
+		if len(driveGlobs) > 0 || len(nodeGlobs) > 0 {
+			klog.Warning("Glob matches will be deprecated soon. Please use ellipses instead")
+		}
+		return purgeDrives(c.Context(), args)
+	},
+	Aliases: []string{},
+}
+
+func init() {
+	purgeDrivesCmd.PersistentFlags().StringSliceVarP(&drives, "drives", "d", drives, "filter by drive path(s) (also accepts ellipses range notations)")
+	purgeDrivesCmd.PersistentFlags().StringSliceVarP(&nodes, "nodes", "n", nodes, "filter by node name(s) (also accepts ellipses range notations)")
+	purgeDrivesCmd.PersistentFlags().BoolVarP(&all, "all", "a", all, "purge all lost drives")
+	purgeDrivesCmd.PersistentFlags().StringSliceVarP(&accessTiers, "access-tier", "", accessTiers,
+		"purge based on access-tier set. The possible values are hot|cold|warm")
+}
+
+func purgeDrives(ctx context.Context, IDArgs []string) error {
+	return processFilteredDrives(
+		ctx,
+		IDArgs,
+		func(drive *directcsi.DirectCSIDrive) bool {
+			path := canonicalNameFromPath(drive.Status.Path)
+			driveAddr := fmt.Sprintf("%s:/dev/%s", drive.Status.NodeName, path)
+			if !utils.IsCondition(drive.Status.Conditions,
+				string(directcsi.DirectCSIDriveConditionReady),
+				metav1.ConditionFalse,
+				string(directcsi.DirectCSIDriveReasonLost),
+				string(directcsi.DirectCSIDriveMessageLost)) {
+				klog.Errorf("%s is intact. Only lost|detached drive can be purged", utils.Bold(driveAddr))
+				return false
+			}
+			if drive.Status.DriveStatus == directcsi.DriveStatusInUse {
+				klog.Errorf("%s is in use. Please purge the corresponding volumes first", utils.Bold(driveAddr))
+				return false
+			}
+			return true
+		},
+		func(drive *directcsi.DirectCSIDrive) error {
+			drive.Finalizers = []string{}
+			utils.UpdateCondition(
+				drive.Status.Conditions,
+				string(directcsi.DirectCSIDriveConditionOwned),
+				metav1.ConditionFalse,
+				string(directcsi.DirectCSIDriveReasonAdded),
+				"",
+			)
+			return nil
+		},
+		func(ctx context.Context, drive *directcsi.DirectCSIDrive) error {
+			driveClient := client.GetLatestDirectCSIDriveInterface()
+			if _, err := driveClient.Update(ctx, drive, metav1.UpdateOptions{
+				TypeMeta: utils.DirectCSIDriveTypeMeta(),
+			}); err != nil {
+				return err
+			}
+			if err := driveClient.Delete(ctx, drive.Name, metav1.DeleteOptions{}); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					return err
+				}
+			}
+			return nil
+		},
+		DrivePurge,
+	)
+}

--- a/cmd/kubectl-directpv/drives_purge_test.go
+++ b/cmd/kubectl-directpv/drives_purge_test.go
@@ -1,0 +1,116 @@
+// This file is part of MinIO DirectPV
+// Copyright (c) 2021, 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/minio/directpv/pkg/client"
+	"github.com/minio/directpv/pkg/utils"
+
+	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
+	clientsetfake "github.com/minio/directpv/pkg/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestPurgeDrives(t1 *testing.T) {
+	createTestDrive := func(name, path string, driveStatus directcsi.DriveStatus, conditions []metav1.Condition) *directcsi.DirectCSIDrive {
+		csiDrive := &directcsi.DirectCSIDrive{
+			TypeMeta: utils.DirectCSIDriveTypeMeta(),
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  metav1.NamespaceNone,
+				Finalizers: []string{string(directcsi.DirectCSIDriveFinalizerDataProtection)},
+			},
+			Status: directcsi.DirectCSIDriveStatus{
+				Path:        path,
+				DriveStatus: driveStatus,
+				Conditions:  conditions,
+			},
+		}
+		return csiDrive
+	}
+
+	testDriveObjects := []runtime.Object{
+		createTestDrive("d1", "/dev/sda1", directcsi.DriveStatusAvailable, []metav1.Condition{
+			{
+				Type:    string(directcsi.DirectCSIVolumeConditionReady),
+				Status:  metav1.ConditionTrue,
+				Message: "",
+				Reason:  string(directcsi.DirectCSIVolumeReasonReady),
+			},
+		}),
+		createTestDrive("d2", "/dev/sda2", directcsi.DriveStatusInUse, []metav1.Condition{
+			{
+				Type:    string(directcsi.DirectCSIVolumeConditionReady),
+				Status:  metav1.ConditionTrue,
+				Message: "",
+				Reason:  string(directcsi.DirectCSIVolumeReasonReady),
+			},
+		}),
+		createTestDrive("d3", "/dev/sda3", directcsi.DriveStatusInUse, []metav1.Condition{
+			{
+				Type:    string(directcsi.DirectCSIVolumeConditionReady),
+				Status:  metav1.ConditionFalse,
+				Message: string(directcsi.DirectCSIDriveMessageLost),
+				Reason:  string(directcsi.DirectCSIDriveReasonLost),
+			},
+		}),
+		createTestDrive("d4", "/dev/sda4", directcsi.DriveStatusReady, []metav1.Condition{
+			{
+				Type:    string(directcsi.DirectCSIVolumeConditionReady),
+				Status:  metav1.ConditionFalse,
+				Message: string(directcsi.DirectCSIDriveMessageLost),
+				Reason:  string(directcsi.DirectCSIDriveReasonLost),
+			},
+		}),
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	testClientSet := clientsetfake.NewSimpleClientset(testDriveObjects...)
+	driveInterface := testClientSet.DirectV1beta4().DirectCSIDrives()
+	client.SetLatestDirectCSIDriveInterface(driveInterface)
+
+	if err := validateDriveSelectors(); err != nil {
+		t1.Fatalf("validateDriveSelectors failed with %v", err)
+	}
+
+	if err := purgeDrives(ctx, nil); err != nil {
+		t1.Fatalf("purgeDrives failed with %v", err)
+	}
+
+	drives, err := client.GetDriveList(ctx, nil, nil, nil)
+	if err != nil {
+		t1.Fatalf("couldn't get the volume list due to %v", err)
+	}
+	// only ready and lost drive should be removed
+	if len(drives) != 3 {
+		t1.Errorf("expected drives count: 3 but got %d", len(drives))
+	}
+
+	var intactDriveNames []string
+	for _, drive := range drives {
+		intactDriveNames = append(intactDriveNames, drive.Name)
+	}
+	if !reflect.DeepEqual(intactDriveNames, []string{"d1", "d2", "d3"}) {
+		t1.Errorf("unexpected result list after purging: %v", intactDriveNames)
+	}
+}

--- a/cmd/kubectl-directpv/install.go
+++ b/cmd/kubectl-directpv/install.go
@@ -39,7 +39,6 @@ var installCmd = &cobra.Command{
 }
 
 var (
-	installCRD             = false
 	admissionControl       = false
 	image                  = "directpv:" + Version
 	registry               = "quay.io"
@@ -53,13 +52,11 @@ var (
 )
 
 func init() {
-	installCmd.PersistentFlags().BoolVarP(&installCRD, "crd", "c", installCRD, "register crds along with installation")
 	installCmd.PersistentFlags().StringVarP(&image, "image", "i", image, "DirectPV image")
 	installCmd.PersistentFlags().StringSliceVarP(&imagePullSecrets, "image-pull-secrets", "", imagePullSecrets, "image pull secrets to be set in pod specs")
 	installCmd.PersistentFlags().StringVarP(&registry, "registry", "r", registry, "registry where DirectPV images are available")
 	installCmd.PersistentFlags().StringVarP(&org, "org", "g", org, "organization name where DirectPV images are available")
 	installCmd.PersistentFlags().BoolVarP(&admissionControl, "admission-control", "", admissionControl, "turn on DirectPV admission controller")
-	installCmd.PersistentFlags().MarkDeprecated("crd", "Will be removed in version 1.5 or greater")
 	installCmd.PersistentFlags().StringSliceVarP(&nodeSelectorParameters, "node-selector", "n", nodeSelectorParameters, "node selector parameters")
 	installCmd.PersistentFlags().StringSliceVarP(&tolerationParameters, "tolerations", "t", tolerationParameters, "tolerations parameters")
 	installCmd.PersistentFlags().StringVarP(&seccompProfile, "seccomp-profile", "", seccompProfile, "set Seccomp profile")

--- a/cmd/kubectl-directpv/uninstall.go
+++ b/cmd/kubectl-directpv/uninstall.go
@@ -41,8 +41,11 @@ var (
 )
 
 func init() {
-	uninstallCmd.PersistentFlags().BoolVarP(&uninstallCRD, "crd", "c", uninstallCRD, "unregister direct.csi.min.io group crds")
+	uninstallCmd.PersistentFlags().BoolVarP(&uninstallCRD, "crd", "c", uninstallCRD, "unregister direct.csi.min.io group crds [May cause data loss]")
 	uninstallCmd.PersistentFlags().BoolVarP(&forceRemove, "force", "", forceRemove, "Removes the direct.csi.min.io resources [May cause data loss]")
+
+	uninstallCmd.PersistentFlags().MarkHidden("crd")
+	uninstallCmd.PersistentFlags().MarkHidden("force")
 }
 
 func uninstall(ctx context.Context, args []string) error {

--- a/cmd/kubectl-directpv/utils.go
+++ b/cmd/kubectl-directpv/utils.go
@@ -69,6 +69,8 @@ const (
 	DriveRelease Command = "driveRelease"
 	// VolumePurge is a volume sub-command to purge the released/failed volumes
 	VolumePurge Command = "volumePurge"
+	// DrivePurge is the sub-command to purge the lost drive
+	DrivePurge Command = "drivePurge"
 )
 
 func printableString(s string) string {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@ Troubleshooting
 
 ### Cleaning up abandoned volumes from a "Terminating" drive
 
+(NOTE: "Terminating" state is deprecated in versions > v3.0.0)
+
 A drive with **Terminating** state indicates that an InUse drive was removed physically from the system and volumes on the drive are unreachable. If a new drive is attached as replacement of the removed drive, it is considered as a new drive and follow steps as mentioned [here](https://github.com/minio/directpv/blob/master/docs/cli.md#format-and-add-drives-to-directpv) to make use of the new drive.
 
 ```sh
@@ -30,3 +32,22 @@ persistentvolumeclaim "minio-data-1-minio-2" deleted
 ```
 
 The deleted PVCs will be re-created and provisions volumes successfully on the remaining "Ready" or "InUse" drives based on the requested topology specifications.
+
+### Purging the released or failed volumes
+
+`kubectl directpv volumes purge` command can be used to purge the lost, failed or released volumes in the cluster. This command should be used for special cases like one of the following
+
+- When the pods and corresponding PVCs were force deleted. Force deletion might skip few necessary volume cleanups and make them stale.
+- When the corresponding drive is removed or detached from the cluster. `kubectl directpv volumes list` would indicate such lost volumes with an error tag.
+- The volumes were deleted when directpv pod running in that node was node.
+- etc..
+
+Plese check `kubectl directpv volumes purge --help` for more helpers.
+
+(NOTE: The PVs of these stale volumes should be in "released" or "failed" state in-order to purge them)
+
+### Purging the removed / detached drive
+
+After v3.0.0, the removed or detached drive will show up in the drives list with an error message indicating that the drive is removed. If the drive is in InUse state, the corresponding volumes need to be purged first. ie, the corresponding PVCs has to be cleaned-up first.
+
+(NOTE: before deleting the lost PVCs, please [cordon](https://kubernetes.io/docs/concepts/architecture/nodes/) the node, to avoid any PVC conflicts)

--- a/minio.yaml
+++ b/minio.yaml
@@ -58,11 +58,6 @@ spec:
       name: minio-data-1
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      # selector: // claim Selector is not supported for dynamic provisioning
-      #   matchLabels: 
-      #     direct.csi.min.io/access-tier: "Hot"
-      #   matchExpressions:
-      #     - {key: direct.csi.min.io/access-tier, operator: In, values: [Hot]}
       resources:
         requests:
           storage: 100Mi    


### PR DESCRIPTION
This command can be used to purge/clean-up the detached/removed drives from the cluster. This command can be
executed only on the detached drive

Steps to test :

- Use the following script to create LVs from local available root disk

```
sudo truncate --size=1G /tmp/disk-{1..4}.img        
for disk in /tmp/disk-{1..4}.img; do sudo losetup --find $disk; done
devices=( $(for disk in /tmp/disk-{1..4}.img; do sudo losetup --noheadings --output NAME --associated $disk; done) )
sudo pvcreate "${devices[@]}"
vgname="vg0"
sudo vgcreate "$vgname" "${devices[@]}"
# for i in {1..4}; do sudo lvcreate --size=800MiB "$vgname"; done
for lvname in lv-{0..3}; do sudo lvcreate --name="$lvname" --size=800MiB "$vgname"; done
```
- Start minikube: minikube start --memory 12000  --driver=none
- Install directpv
- Attach a pendrive, The attached media device should show up in the drives list `kubectl directpv drives list --all`
- Detach the pendrive
- The `kubectl directpv drives list --all` should indicate that the drive is removed
- Purge the removed pendrive by `kubectl directpv drives purge --drives /dev/<drive>` 
- The drive should be removed from the `kubectl directpv drives list --all`

This can also be tested with VMs. You can attach and detach a device by `virsh attach-device` and `virsh detach-device`. Please refer run-functests-on-centos7-vm.sh for the steps.