### PR TITLE
Increase lease renewal timeout for drive and volume controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/klauspost/cpuid/v2 v2.0.4 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -18,6 +18,7 @@ package listener
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -43,6 +44,10 @@ import (
 	"k8s.io/klog/v2"
 
 	"golang.org/x/time/rate"
+)
+
+var (
+	errLeaderElectionDied = errors.New("leaderelection died")
 )
 
 func getNamespace() string {
@@ -140,7 +145,7 @@ func NewListener(handler EventHandler, identity, leaderLock string, threadiness 
 		handler: handler,
 
 		LeaseDuration: 1 * time.Minute,
-		RenewDeadline: 10 * time.Second,
+		RenewDeadline: 50 * time.Second,
 		RetryPeriod:   5 * time.Second,
 
 		ResyncPeriod: 1 * time.Minute,
@@ -386,5 +391,5 @@ func (listener *Listener) Run(ctx context.Context) error {
 	}
 
 	leaderelection.RunOrDie(ctx, leaderConfig)
-	return nil // should never reach here
+	return errLeaderElectionDied
 }

--- a/pkg/listener/listener_test.go
+++ b/pkg/listener/listener_test.go
@@ -83,7 +83,7 @@ func startTestController(ctx context.Context, t *testing.T, handler *testEventHa
 
 	listener := NewListener(handler, "test-volume-controller", hostname, threadiness)
 	go func() {
-		if err := listener.Run(ctx); err != nil {
+		if err := listener.Run(ctx); err != nil && err != errLeaderElectionDied {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
When there are any network slowness in the cluster, having a lesser timeout would easily
give-up renenewing the lease.

Fixes #595

Steps to test:

I was able to reproduce the issue by running the pods for quite few hours. With this PR, the drive and volume controllers should not stop leading. Even if it stops, the leader will be re-elected.