### PR TITLE
Remove SMART serial number validation checks as we don't use SMART serials anymore

### DIFF
--- a/pkg/uevent/utils.go
+++ b/pkg/uevent/utils.go
@@ -170,10 +170,6 @@ func validateSysInfo(device *sys.Device, directCSIDrive *directcsi.DirectCSIDriv
 }
 
 func validateDevInfo(device *sys.Device, directCSIDrive *directcsi.DirectCSIDrive) bool {
-	if directCSIDrive.Status.SerialNumber != device.Serial {
-		klog.V(3).Infof("[%s] mismatch serial %v - %v", device.Name, directCSIDrive.Status.SerialNumber, device.Serial)
-		return false
-	}
 	if directCSIDrive.Status.FilesystemUUID != device.FSUUID {
 		klog.V(3).Infof("[%s] mismatch fsuuid %v - %v", device.Name, directCSIDrive.Status.FilesystemUUID, device.FSUUID)
 		return false

--- a/pkg/uevent/utils_test.go
+++ b/pkg/uevent/utils_test.go
@@ -1057,29 +1057,6 @@ func TestValidateDevInfo(t1 *testing.T) {
 					Name: "test-drive",
 				},
 				Status: directcsi.DirectCSIDriveStatus{
-					SerialNumber:   "serial2",
-					FilesystemUUID: "fsuuid",
-					ReadOnly:       false,
-					Mountpoint:     "/var/lib/direct-csi/mnt/test-drive",
-					SwapOn:         false,
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			device: &sys.Device{
-				Serial:          "serial",
-				FSUUID:          "fsuuid",
-				ReadOnly:        false,
-				FirstMountPoint: "/var/lib/direct-csi/mnt/test-drive",
-				SwapOn:          false,
-			},
-			drive: &directcsi.DirectCSIDrive{
-				TypeMeta: utils.DirectCSIDriveTypeMeta(),
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-drive",
-				},
-				Status: directcsi.DirectCSIDriveStatus{
 					SerialNumber:   "serial",
 					FilesystemUUID: "fsuuid2",
 					ReadOnly:       false,


### PR DESCRIPTION
This is a just a log clean-up PR. SMART probes aren't used anymore, so, we can remove the references to it.