### PR TITLE
Add "noatime" as a default flag while mounting drives

### DIFF
--- a/cmd/directpv/run.go
+++ b/cmd/directpv/run.go
@@ -134,8 +134,8 @@ func checkXFS(ctx context.Context, reflinkSupport bool) error {
 		}
 	}()
 
-	if err = mount.Mount(loopDevice.Path(), mountPoint, "xfs", nil, ""); err != nil {
-		klog.V(3).ErrorS(err, "failed to mount", "reflink", reflinkSupport)
+	if err = mount.Mount(loopDevice.Path(), mountPoint, "xfs", []string{mount.MountFlagNoAtime}, mount.MountOptPrjQuota); err != nil {
+		klog.V(3).ErrorS(err, "failed to mount", "reflink", reflinkSupport, "flags", mount.MountFlagNoAtime, "mountopts", mount.MountOptPrjQuota)
 		return errMountFailure
 	}
 

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -29,6 +29,8 @@ const (
 	MountOptPrjQuota = "prjquota"
 	// rw option for project quota
 	MountOptRW = "rw"
+	// MountFlagNoAtime - "noatime" mount flag
+	MountFlagNoAtime = "noatime"
 )
 
 // Mount mounts device to target using fsType, flags and superBlockFlags.
@@ -66,9 +68,11 @@ func MountXFSDevice(device, target string, flags []string) error {
 	if err := os.MkdirAll(target, 0777); err != nil {
 		return err
 	}
-
-	klog.V(3).InfoS("mounting device", "device", device, "target", target)
-	return SafeMount(device, target, "xfs", flags, MountOptPrjQuota)
+	// mount with "noatime" by default
+	flags = append(flags, MountFlagNoAtime)
+	// safemounting with "prjquota" mountopt
+	klog.V(3).InfoS("mounting device", "device", device, "target", target, "flags", flags, "mountopts", MountOptPrjQuota)
+	return safeMount(device, target, "xfs", flags, MountOptPrjQuota)
 }
 
 // ValidDirectPVMountOpts checks for valid mount opts


### PR DESCRIPTION
"noatime" for mount opts will increase the performance by avoiding intermediate WRITEs for reads. The WRITEs here are because for atime updates when the files are accessed. Setting "noatime" will skip this.
