### PR TITLE
Add a flag to disable udev listener

### DIFF
--- a/cmd/directpv/cmd.go
+++ b/cmd/directpv/cmd.go
@@ -51,6 +51,7 @@ var (
 	dynamicDriveDiscovery = false
 	dynamicDriveHandler   = false
 	metricsPort           = 10443
+	disableUDevListener   = false
 )
 
 var driverCmd = &cobra.Command{
@@ -115,6 +116,7 @@ func init() {
 	driverCmd.Flags().BoolVarP(&dynamicDriveDiscovery, "dynamic-drive-discovery", "", dynamicDriveDiscovery, "Enable dynamic drive discovery (disabled by default) (experimental)")
 	driverCmd.Flags().BoolVarP(&dynamicDriveHandler, "dynamic-drive-handler", "", dynamicDriveHandler, "running in dynamic drive handler mode (experimental)")
 	driverCmd.Flags().IntVarP(&metricsPort, "metrics-port", "", metricsPort, "Metrics port for scraping. default is 10443")
+	driverCmd.Flags().BoolVarP(&disableUDevListener, "disable-udev-listener", "", disableUDevListener, "disable uevent listener and rely on 30secs internal drive-sync mechanism")
 
 	driverCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	driverCmd.PersistentFlags().MarkHidden("log_backtrace_at")

--- a/cmd/directpv/run.go
+++ b/cmd/directpv/run.go
@@ -155,6 +155,7 @@ func run(ctxMain context.Context, args []string) error {
 			rack,
 			zone,
 			region,
+			disableUDevListener,
 		)
 	}
 

--- a/cmd/kubectl-directpv/install.go
+++ b/cmd/kubectl-directpv/install.go
@@ -49,6 +49,7 @@ var (
 	apparmorProfile        = ""
 	auditInstall           = "install"
 	imagePullSecrets       = []string{}
+	disableUDevListener    = false
 )
 
 func init() {
@@ -61,6 +62,7 @@ func init() {
 	installCmd.PersistentFlags().StringSliceVarP(&tolerationParameters, "tolerations", "t", tolerationParameters, "tolerations parameters")
 	installCmd.PersistentFlags().StringVarP(&seccompProfile, "seccomp-profile", "", seccompProfile, "set Seccomp profile")
 	installCmd.PersistentFlags().StringVarP(&apparmorProfile, "apparmor-profile", "", apparmorProfile, "set Apparmor profile")
+	installCmd.PersistentFlags().BoolVarP(&disableUDevListener, "disable-udev-listener", "", disableUDevListener, "disable uevent listener and rely on 30secs internal drive-sync mechanism")
 }
 
 func install(ctx context.Context, args []string) (err error) {
@@ -109,6 +111,7 @@ func install(ctx context.Context, args []string) (err error) {
 		DryRun:                     dryRun,
 		AuditFile:                  file,
 		ImagePullSecrets:           imagePullSecrets,
+		DisableUDevListener:        disableUDevListener,
 	}
 
 	return installer.Install(ctx, installConfig)

--- a/pkg/installer/config.go
+++ b/pkg/installer/config.go
@@ -89,6 +89,9 @@ type Config struct {
 	// internal
 	conversionWebhookCaBundle []byte
 	validationWebhookCaBundle []byte
+
+	// Drive discovery
+	DisableUDevListener bool
 }
 
 type installer interface {

--- a/pkg/installer/daemonset.go
+++ b/pkg/installer/daemonset.go
@@ -229,6 +229,11 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 			fmt.Sprintf("--node-id=$(%s)", kubeNodeNameEnvVar),
 			"--dynamic-drive-handler",
 		}
+
+		if c.DisableUDevListener {
+			args = append(args, "--disable-udev-listener")
+		}
+
 		podSpec.Containers = append(podSpec.Containers, corev1.Container{
 			Name:            directPVDriveDiscoveryContainerName,
 			Image:           filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),

--- a/pkg/node/uevent.go
+++ b/pkg/node/uevent.go
@@ -33,7 +33,8 @@ import (
 
 // RunDynamicDriveHandler starts the listener
 func RunDynamicDriveHandler(ctx context.Context,
-	identity, nodeID, rack, zone, region string) error {
+	identity, nodeID, rack, zone, region string,
+	disableUDevListener bool) error {
 
 	handler := &driveEventHandler{
 		nodeID: nodeID,
@@ -46,7 +47,7 @@ func RunDynamicDriveHandler(ctx context.Context,
 		},
 	}
 
-	return uevent.Run(ctx, nodeID, handler)
+	return uevent.Run(ctx, nodeID, handler, disableUDevListener)
 }
 
 type driveEventHandler struct {

--- a/pkg/uevent/listener_other.go
+++ b/pkg/uevent/listener_other.go
@@ -25,6 +25,6 @@ import (
 )
 
 // Run starts identity/controller/node servers.
-func Run(ctx context.Context, nodeID string, handler DeviceUEventHandler) error {
+func Run(ctx context.Context, nodeID string, handler DeviceUEventHandler, disableUDevListener bool) error {
 	return fmt.Errorf("unsupported operating system %v", runtime.GOOS)
 }


### PR DESCRIPTION
setting `--disable-udev-listener` during install will disable udev monitoring. This will skip
listening for the udev Add, Change and Remove events and relies on internal sync mechanism in-place
to sync the drive states.

Steps to test :
- run `./build.sh`
- build and push the image
- ./kubectl-directpv install --disable-udev-listener --org <org> --image <image>
- basic tests like formatting, releasing drives (This should take minimum 30secs to reflect)