### PR TITLE
Support virtual disks by relaxing the hashed uuid generation for the drive names

### DIFF
--- a/pkg/node/uevent_test.go
+++ b/pkg/node/uevent_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
@@ -397,125 +396,6 @@ func TestAddHandler(t *testing.T) {
 		) {
 			t.Fatalf("case %d found Ready condition to be false", i)
 		}
-	}
-}
-
-func TestAddHandlerWithRace(t *testing.T) {
-	devices := []*sys.Device{
-		{
-			Name:              "name",
-			Major:             200,
-			Minor:             2,
-			Size:              uint64(5368709120),
-			WWID:              "wwid",
-			Model:             "model",
-			Serial:            "serial",
-			Vendor:            "vendor",
-			DMName:            "dmname",
-			DMUUID:            "dmuuid",
-			MDUUID:            "mduuid",
-			PTUUID:            "ptuuid",
-			PTType:            "gpt",
-			PartUUID:          "partuuid",
-			FSUUID:            "fsuuid",
-			FSType:            "xfs",
-			UeventSerial:      "ueventserial",
-			UeventFSUUID:      "ueventfsuuid",
-			TotalCapacity:     uint64(5368709120),
-			FreeCapacity:      uint64(5368709120),
-			LogicalBlockSize:  uint64(512),
-			PhysicalBlockSize: uint64(512),
-			MountPoints:       []string{"/var/lib/direct-csi/mnt/fsuuid"},
-			FirstMountPoint:   "/var/lib/direct-csi/mnt/fsuuid",
-		},
-		{
-			Name:              "name",
-			Major:             200,
-			Minor:             2,
-			Size:              uint64(5368709120),
-			WWID:              "wwid",
-			Model:             "model",
-			Serial:            "serial",
-			Vendor:            "vendor",
-			DMName:            "dmname",
-			DMUUID:            "dmuuid",
-			MDUUID:            "mduuid",
-			PTUUID:            "ptuuid",
-			PTType:            "gpt",
-			PartUUID:          "partuuid",
-			FSUUID:            "fsuuid",
-			FSType:            "xfs",
-			UeventSerial:      "ueventserial",
-			UeventFSUUID:      "ueventfsuuid",
-			TotalCapacity:     uint64(5368709120),
-			FreeCapacity:      uint64(5368709120),
-			LogicalBlockSize:  uint64(512),
-			PhysicalBlockSize: uint64(512),
-			MountPoints:       []string{"/var/lib/direct-csi/mnt/fsuuid"},
-			FirstMountPoint:   "/var/lib/direct-csi/mnt/fsuuid",
-		},
-		{
-			Name:              "name",
-			Major:             200,
-			Minor:             2,
-			Size:              uint64(5368709120),
-			WWID:              "wwid",
-			Model:             "model",
-			Serial:            "serial",
-			Vendor:            "vendor",
-			DMName:            "dmname",
-			DMUUID:            "dmuuid",
-			MDUUID:            "mduuid",
-			PTUUID:            "ptuuid",
-			PTType:            "gpt",
-			PartUUID:          "partuuid",
-			FSUUID:            "fsuuid",
-			FSType:            "xfs",
-			UeventSerial:      "ueventserial",
-			UeventFSUUID:      "ueventfsuuid",
-			TotalCapacity:     uint64(5368709120),
-			FreeCapacity:      uint64(5368709120),
-			LogicalBlockSize:  uint64(512),
-			PhysicalBlockSize: uint64(512),
-			MountPoints:       []string{"/var/lib/direct-csi/mnt/fsuuid"},
-			FirstMountPoint:   "/var/lib/direct-csi/mnt/fsuuid",
-		},
-	}
-
-	var wg sync.WaitGroup
-	client.SetLatestDirectCSIDriveInterface(fakedirect.NewSimpleClientset().DirectV1beta4().DirectCSIDrives())
-	ctx := context.TODO()
-	handler := createDriveEventHandler()
-	errs := make(chan error, 1)
-	for _, device := range devices {
-		wg.Add(1)
-		go func(dev *sys.Device) {
-			defer wg.Done()
-			if err := handler.Add(ctx, dev); err != nil {
-				errs <- err
-			}
-		}(device)
-	}
-
-	// close errs once all children finish.
-	go func() {
-		wg.Wait()
-		close(errs)
-	}()
-
-	for err := range errs {
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	result, err := client.GetLatestDirectCSIDriveInterface().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("could not list drives: %v", err)
-	}
-
-	if len(result.Items) != 1 {
-		t.Error("duplicate drives found")
 	}
 }
 

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -17,14 +17,9 @@
 package node
 
 import (
-	"crypto/sha256"
 	"fmt"
-	"strconv"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/minio/directpv/pkg/mount"
-	"github.com/minio/directpv/pkg/sys"
 )
 
 func checkStagingTargetPath(stagingPath string, probeMounts func() (map[string][]mount.MountInfo, error)) error {
@@ -42,40 +37,4 @@ func checkStagingTargetPath(stagingPath string, probeMounts func() (map[string][
 	}
 
 	return fmt.Errorf("stagingPath %v is not mounted", stagingPath)
-}
-
-func getDriveUUID(nodeID string, device *sys.Device) string {
-	data := []byte(
-		strings.Join(
-			[]string{
-				nodeID,
-				device.WWID,
-				device.UeventSerial,
-				device.DMUUID,
-				device.SerialLong,
-				device.PCIPath,
-				strconv.Itoa(device.Partition),
-			},
-			"",
-		),
-	)
-	h := sha256.Sum256(data)
-	return uuid.UUID{
-		h[0],
-		h[1],
-		h[2],
-		h[3],
-		h[4],
-		h[5],
-		h[6],
-		h[7],
-		h[8],
-		h[9],
-		h[10],
-		h[11],
-		h[12],
-		h[13],
-		h[14],
-		h[15],
-	}.String()
 }

--- a/pkg/uevent/match.go
+++ b/pkg/uevent/match.go
@@ -173,7 +173,7 @@ func matchDrives(drives []*directcsi.DirectCSIDrive, device *sys.Device) (*direc
 	case 0:
 		return nil, noMatch
 	case 1:
-		if IsFormatRequested(drives[0]) || isChanged(device, drives[0]) {
+		if IsFormatRequested(matchedDrives[0]) || isChanged(device, matchedDrives[0]) {
 			return matchedDrives[0], changed
 		}
 		return matchedDrives[0], noChange


### PR DESCRIPTION
currently, the name of the newly created drive is a uuid which will be calculated by
the hash of the hardware persistent properties of the drive. This prevents creation of
any virtual disks which will not have any ids on them.

by assigning random uuids for the drive names, we accept such virtual disks

Fixes #580