### PR TITLE
cleanup code with 'gofumpt'

### DIFF
--- a/.github/workflows/functional-test-1.18.20-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.18.20-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.18.20.yaml
+++ b/.github/workflows/functional-test-1.18.20.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.19.16-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.19.16-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.19.16.yaml
+++ b/.github/workflows/functional-test-1.19.16.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.20.14-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.20.14-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.20.14.yaml
+++ b/.github/workflows/functional-test-1.20.14.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.21.8-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.21.8-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.21.8.yaml
+++ b/.github/workflows/functional-test-1.21.8.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.22.5-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.22.5-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.22.5.yaml
+++ b/.github/workflows/functional-test-1.22.5.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.23.3-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.23.3-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/functional-test-1.23.3.yaml
+++ b/.github/workflows/functional-test-1.23.3.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17.x
+      - name: Set up Go 1.18.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
         
       # https://github.com/docker/setup-qemu-action

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,17 +48,15 @@ jobs:
           curl -L -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${nancy_version}/nancy-${nancy_version}-linux-amd64 && chmod +x nancy
           go list -deps -json ./... | jq -s 'unique_by(.Module.Path)|.[]|select(has("Module"))|.Module' | ./nancy sleuth
           
-      - name: Build and upload coverage to Codecov
+      - name: Build and run tests
         env:
           CGO_ENABLED: 0
           GO111MODULE: on
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           diff -au <(gofmt -s -d cmd) <(printf "")
           diff -au <(gofmt -s -d pkg) <(printf "")
-          go test -v ./... -tags skip -coverprofile="codecov-coverage.txt" -covermode=atomic
+          go test -v ./...
           ./build.sh
-          curl -s https://codecov.io/bash | bash -s -- -f "codecov-coverage.txt" -F ubuntu-latest
           docker build . -t "directpv:latest"
 
       - name: Run GoReleaser

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,15 +23,15 @@ jobs:
         env:
           SHELLCHECK_OPTS: -e SC1091
 
-      - name: Set up Go 1.17.x
+      - name: Set up Go 1.18.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.47.3
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,14 +10,31 @@ linters-settings:
   misspell:
     locale: US
 
+  gofumpt:
+    lang-version: "1.17"
+
+    # Choose whether or not to use the extra rules that are disabled
+    # by default
+    extra-rules: false
+
+
 linters:
+  disable-all: true
   enable:
+    - typecheck
     - goimports
     - goheader
     - misspell
-    - structcheck
+    - govet
+    - ineffassign
+    - deadcode
     - gomodguard
     - gofmt
+    - varcheck
+    - gofumpt
+    - tenv
+    - durationcheck
+
 
 issues:
   exclude-use-default: false

--- a/cmd/kubectl-directpv/cmd.go
+++ b/cmd/kubectl-directpv/cmd.go
@@ -38,7 +38,7 @@ var (
 	kubeconfig = ""
 	identity   = "direct.csi.min.io"
 	dryRun     = false
-	//output modes
+	// output modes
 	outputMode = ""
 	wide       = false
 	json       = false
@@ -46,9 +46,11 @@ var (
 	noHeaders  = false
 )
 
-var drives, nodes, driveGlobs, nodeGlobs []string
-var driveSelectorValues, nodeSelectorValues []utils.LabelValue
-var printer func(interface{}) error
+var (
+	drives, nodes, driveGlobs, nodeGlobs    []string
+	driveSelectorValues, nodeSelectorValues []utils.LabelValue
+	printer                                 func(interface{}) error
+)
 
 var pluginCmd = &cobra.Command{
 	Use:           utils.BinaryName(),
@@ -127,7 +129,7 @@ func init() {
 	pluginCmd.AddCommand(uninstallCmd)
 	pluginCmd.AddCommand(drivesCmd)
 	pluginCmd.AddCommand(volumesCmd)
-	//pluginCmd.AddCommand(newVolumesCmd())
+	// pluginCmd.AddCommand(newVolumesCmd())
 }
 
 // Execute executes plugin command.

--- a/cmd/kubectl-directpv/drives.go
+++ b/cmd/kubectl-directpv/drives.go
@@ -22,9 +22,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var status, accessTiers, statusGlobs []string
-var accessTierSelectorValues []utils.LabelValue
-var driveStatusList []directcsi.DriveStatus
+var (
+	status, accessTiers, statusGlobs []string
+	accessTierSelectorValues         []utils.LabelValue
+	driveStatusList                  []directcsi.DriveStatus
+)
 
 var drivesCmd = &cobra.Command{
 	Use:   "drives",

--- a/cmd/kubectl-directpv/drives_format.go
+++ b/cmd/kubectl-directpv/drives_format.go
@@ -30,9 +30,7 @@ import (
 
 const xfs = "xfs"
 
-var (
-	force = false
-)
+var force = false
 
 var formatDrivesCmd = &cobra.Command{
 	Use:   "format",

--- a/cmd/kubectl-directpv/utils.go
+++ b/cmd/kubectl-directpv/utils.go
@@ -21,6 +21,7 @@ import (
 	encodingjson "encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -117,7 +118,8 @@ func processFilteredDrives(
 	idArgs []string,
 	matchFunc func(*directcsi.DirectCSIDrive) bool,
 	applyFunc func(*directcsi.DirectCSIDrive) error,
-	processFunc func(context.Context, *directcsi.DirectCSIDrive) error, command Command) error {
+	processFunc func(context.Context, *directcsi.DirectCSIDrive) error, command Command,
+) error {
 	var resultCh <-chan client.ListDriveResult
 	var err error
 	if len(idArgs) > 0 {
@@ -343,7 +345,7 @@ func getDirectCSIPath(driveName string) string {
 	if strings.HasPrefix(driveName, sys.HostDevRoot) {
 		return getDirectCSIPath(filepath.Base(driveName))
 	}
-	return filepath.Join(sys.DirectCSIDevRoot, driveName)
+	return path.Join(sys.DirectCSIDevRoot, driveName)
 }
 
 func processFilteredVolumes(
@@ -351,7 +353,8 @@ func processFilteredVolumes(
 	idArgs []string,
 	matchFunc func(*directcsi.DirectCSIVolume) bool,
 	applyFunc func(*directcsi.DirectCSIVolume) error,
-	processFunc func(context.Context, *directcsi.DirectCSIVolume) error, command Command) error {
+	processFunc func(context.Context, *directcsi.DirectCSIVolume) error, command Command,
+) error {
 	var resultCh <-chan client.ListVolumeResult
 	var err error
 	if len(idArgs) > 0 {

--- a/cmd/kubectl-directpv/validate_image.go
+++ b/cmd/kubectl-directpv/validate_image.go
@@ -968,6 +968,7 @@ func parseTag2(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag3(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag4, false, nil
@@ -989,6 +990,7 @@ func parseTag3(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag4(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag5, false, nil
@@ -1010,6 +1012,7 @@ func parseTag4(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag5(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag6, false, nil
@@ -1031,6 +1034,7 @@ func parseTag5(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag6(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag7, false, nil
@@ -1052,6 +1056,7 @@ func parseTag6(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag7(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag8, false, nil
@@ -1073,6 +1078,7 @@ func parseTag7(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag8(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag9, false, nil
@@ -1094,6 +1100,7 @@ func parseTag8(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag9(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag10, false, nil
@@ -1115,6 +1122,7 @@ func parseTag9(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag10(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag11, false, nil
@@ -1136,6 +1144,7 @@ func parseTag10(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag11(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag12, false, nil
@@ -1157,6 +1166,7 @@ func parseTag11(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag12(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag13, false, nil
@@ -1178,6 +1188,7 @@ func parseTag12(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag13(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag14, false, nil
@@ -1199,6 +1210,7 @@ func parseTag13(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag14(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag15, false, nil
@@ -1220,6 +1232,7 @@ func parseTag14(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag15(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag16, false, nil
@@ -1241,6 +1254,7 @@ func parseTag15(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag16(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag17, false, nil
@@ -1262,6 +1276,7 @@ func parseTag16(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag17(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag18, false, nil
@@ -1283,6 +1298,7 @@ func parseTag17(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag18(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag19, false, nil
@@ -1304,6 +1320,7 @@ func parseTag18(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag19(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag20, false, nil
@@ -1325,6 +1342,7 @@ func parseTag19(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag20(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag21, false, nil
@@ -1346,6 +1364,7 @@ func parseTag20(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag21(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag22, false, nil
@@ -1367,6 +1386,7 @@ func parseTag21(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag22(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag23, false, nil
@@ -1388,6 +1408,7 @@ func parseTag22(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag23(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag24, false, nil
@@ -1409,6 +1430,7 @@ func parseTag23(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag24(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag25, false, nil
@@ -1430,6 +1452,7 @@ func parseTag24(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag25(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag26, false, nil
@@ -1451,6 +1474,7 @@ func parseTag25(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag26(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag27, false, nil
@@ -1472,6 +1496,7 @@ func parseTag26(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag27(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag28, false, nil
@@ -1493,6 +1518,7 @@ func parseTag27(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag28(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag29, false, nil
@@ -1514,6 +1540,7 @@ func parseTag28(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag29(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag30, false, nil
@@ -1535,6 +1562,7 @@ func parseTag29(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag30(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag31, false, nil
@@ -1556,6 +1584,7 @@ func parseTag30(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag31(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag32, false, nil
@@ -1577,6 +1606,7 @@ func parseTag31(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag32(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag33, false, nil
@@ -1598,6 +1628,7 @@ func parseTag32(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag33(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag34, false, nil
@@ -1619,6 +1650,7 @@ func parseTag33(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag34(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag35, false, nil
@@ -1640,6 +1672,7 @@ func parseTag34(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag35(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag36, false, nil
@@ -1661,6 +1694,7 @@ func parseTag35(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag36(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag37, false, nil
@@ -1682,6 +1716,7 @@ func parseTag36(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag37(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag38, false, nil
@@ -1703,6 +1738,7 @@ func parseTag37(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag38(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag39, false, nil
@@ -1724,6 +1760,7 @@ func parseTag38(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag39(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag40, false, nil
@@ -1745,6 +1782,7 @@ func parseTag39(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag40(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag41, false, nil
@@ -1766,6 +1804,7 @@ func parseTag40(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag41(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag42, false, nil
@@ -1787,6 +1826,7 @@ func parseTag41(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag42(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag43, false, nil
@@ -1808,6 +1848,7 @@ func parseTag42(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag43(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag44, false, nil
@@ -1829,6 +1870,7 @@ func parseTag43(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag44(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag45, false, nil
@@ -1850,6 +1892,7 @@ func parseTag44(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag45(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag46, false, nil
@@ -1871,6 +1914,7 @@ func parseTag45(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag46(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag47, false, nil
@@ -1892,6 +1936,7 @@ func parseTag46(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag47(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag48, false, nil
@@ -1913,6 +1958,7 @@ func parseTag47(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag48(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag49, false, nil
@@ -1934,6 +1980,7 @@ func parseTag48(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag49(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag50, false, nil
@@ -1955,6 +2002,7 @@ func parseTag49(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag50(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag51, false, nil
@@ -1976,6 +2024,7 @@ func parseTag50(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag51(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag52, false, nil
@@ -1997,6 +2046,7 @@ func parseTag51(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag52(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag53, false, nil
@@ -2018,6 +2068,7 @@ func parseTag52(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag53(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag54, false, nil
@@ -2039,6 +2090,7 @@ func parseTag53(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag54(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag55, false, nil
@@ -2060,6 +2112,7 @@ func parseTag54(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag55(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag56, false, nil
@@ -2081,6 +2134,7 @@ func parseTag55(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag56(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag57, false, nil
@@ -2102,6 +2156,7 @@ func parseTag56(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag57(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag58, false, nil
@@ -2123,6 +2178,7 @@ func parseTag57(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag58(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag59, false, nil
@@ -2144,6 +2200,7 @@ func parseTag58(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag59(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag60, false, nil
@@ -2165,6 +2222,7 @@ func parseTag59(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag60(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag61, false, nil
@@ -2186,6 +2244,7 @@ func parseTag60(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag61(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag62, false, nil
@@ -2207,6 +2266,7 @@ func parseTag61(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag62(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag63, false, nil
@@ -2228,6 +2288,7 @@ func parseTag62(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag63(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag64, false, nil
@@ -2249,6 +2310,7 @@ func parseTag63(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag64(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag65, false, nil
@@ -2270,6 +2332,7 @@ func parseTag64(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag65(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag66, false, nil
@@ -2291,6 +2354,7 @@ func parseTag65(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag66(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag67, false, nil
@@ -2312,6 +2376,7 @@ func parseTag66(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag67(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag68, false, nil
@@ -2333,6 +2398,7 @@ func parseTag67(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag68(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag69, false, nil
@@ -2354,6 +2420,7 @@ func parseTag68(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag69(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag70, false, nil
@@ -2375,6 +2442,7 @@ func parseTag69(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag70(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag71, false, nil
@@ -2396,6 +2464,7 @@ func parseTag70(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag71(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag72, false, nil
@@ -2417,6 +2486,7 @@ func parseTag71(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag72(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag73, false, nil
@@ -2438,6 +2508,7 @@ func parseTag72(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag73(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag74, false, nil
@@ -2459,6 +2530,7 @@ func parseTag73(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag74(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag75, false, nil
@@ -2480,6 +2552,7 @@ func parseTag74(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag75(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag76, false, nil
@@ -2501,6 +2574,7 @@ func parseTag75(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag76(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag77, false, nil
@@ -2522,6 +2596,7 @@ func parseTag76(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag77(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag78, false, nil
@@ -2543,6 +2618,7 @@ func parseTag77(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag78(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag79, false, nil
@@ -2564,6 +2640,7 @@ func parseTag78(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag79(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag80, false, nil
@@ -2585,6 +2662,7 @@ func parseTag79(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag80(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag81, false, nil
@@ -2606,6 +2684,7 @@ func parseTag80(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag81(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag82, false, nil
@@ -2627,6 +2706,7 @@ func parseTag81(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag82(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag83, false, nil
@@ -2648,6 +2728,7 @@ func parseTag82(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag83(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag84, false, nil
@@ -2669,6 +2750,7 @@ func parseTag83(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag84(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag85, false, nil
@@ -2690,6 +2772,7 @@ func parseTag84(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag85(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag86, false, nil
@@ -2711,6 +2794,7 @@ func parseTag85(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag86(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag87, false, nil
@@ -2732,6 +2816,7 @@ func parseTag86(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag87(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag88, false, nil
@@ -2753,6 +2838,7 @@ func parseTag87(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag88(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag89, false, nil
@@ -2774,6 +2860,7 @@ func parseTag88(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag89(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag90, false, nil
@@ -2795,6 +2882,7 @@ func parseTag89(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag90(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag91, false, nil
@@ -2816,6 +2904,7 @@ func parseTag90(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag91(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag92, false, nil
@@ -2837,6 +2926,7 @@ func parseTag91(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag92(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag93, false, nil
@@ -2858,6 +2948,7 @@ func parseTag92(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag93(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag94, false, nil
@@ -2879,6 +2970,7 @@ func parseTag93(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag94(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag95, false, nil
@@ -2900,6 +2992,7 @@ func parseTag94(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag95(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag96, false, nil
@@ -2921,6 +3014,7 @@ func parseTag95(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag96(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag97, false, nil
@@ -2942,6 +3036,7 @@ func parseTag96(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag97(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag98, false, nil
@@ -2963,6 +3058,7 @@ func parseTag97(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag98(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag99, false, nil
@@ -2984,6 +3080,7 @@ func parseTag98(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag99(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag100, false, nil
@@ -3005,6 +3102,7 @@ func parseTag99(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag100(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag101, false, nil
@@ -3026,6 +3124,7 @@ func parseTag100(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag101(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag102, false, nil
@@ -3047,6 +3146,7 @@ func parseTag101(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag102(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag103, false, nil
@@ -3068,6 +3168,7 @@ func parseTag102(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag103(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag104, false, nil
@@ -3089,6 +3190,7 @@ func parseTag103(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag104(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag105, false, nil
@@ -3110,6 +3212,7 @@ func parseTag104(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag105(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag106, false, nil
@@ -3131,6 +3234,7 @@ func parseTag105(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag106(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag107, false, nil
@@ -3152,6 +3256,7 @@ func parseTag106(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag107(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag108, false, nil
@@ -3173,6 +3278,7 @@ func parseTag107(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag108(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag109, false, nil
@@ -3194,6 +3300,7 @@ func parseTag108(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag109(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag110, false, nil
@@ -3215,6 +3322,7 @@ func parseTag109(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag110(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag111, false, nil
@@ -3236,6 +3344,7 @@ func parseTag110(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag111(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag112, false, nil
@@ -3257,6 +3366,7 @@ func parseTag111(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag112(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag113, false, nil
@@ -3278,6 +3388,7 @@ func parseTag112(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag113(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag114, false, nil
@@ -3299,6 +3410,7 @@ func parseTag113(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag114(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag115, false, nil
@@ -3320,6 +3432,7 @@ func parseTag114(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag115(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag116, false, nil
@@ -3341,6 +3454,7 @@ func parseTag115(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag116(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag117, false, nil
@@ -3362,6 +3476,7 @@ func parseTag116(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag117(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag118, false, nil
@@ -3383,6 +3498,7 @@ func parseTag117(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag118(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag119, false, nil
@@ -3404,6 +3520,7 @@ func parseTag118(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag119(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag120, false, nil
@@ -3425,6 +3542,7 @@ func parseTag119(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag120(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag121, false, nil
@@ -3446,6 +3564,7 @@ func parseTag120(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag121(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag122, false, nil
@@ -3467,6 +3586,7 @@ func parseTag121(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag122(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag123, false, nil
@@ -3488,6 +3608,7 @@ func parseTag122(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag123(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag124, false, nil
@@ -3509,6 +3630,7 @@ func parseTag123(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag124(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag125, false, nil
@@ -3530,6 +3652,7 @@ func parseTag124(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag125(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag126, false, nil
@@ -3551,6 +3674,7 @@ func parseTag125(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag126(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag127, false, nil
@@ -3572,6 +3696,7 @@ func parseTag126(r rune) (interface{}, bool, error) {
 	}
 	return parseImage, false, errInvalid("[a-zA-Z_-.0-9]", r)
 }
+
 func parseTag127(r rune) (interface{}, bool, error) {
 	if r >= 'a' && r <= 'z' {
 		return parseTag128, false, nil

--- a/cmd/kubectl-directpv/volumes.go
+++ b/cmd/kubectl-directpv/volumes.go
@@ -21,8 +21,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var volumeStatus, volumeStatusList, podNames, podNameGlobs, podNss, podNsGlobs []string
-var podNameSelectorValues, podNsSelectorValues []utils.LabelValue
+var (
+	volumeStatus, volumeStatusList, podNames, podNameGlobs, podNss, podNsGlobs []string
+	podNameSelectorValues, podNsSelectorValues                                 []utils.LabelValue
+)
 
 var volumesCmd = &cobra.Command{
 	Use:   "volumes",

--- a/cmd/kubectl-directpv/volumes_list.go
+++ b/cmd/kubectl-directpv/volumes_list.go
@@ -82,7 +82,6 @@ func init() {
 }
 
 func listVolumes(ctx context.Context, args []string) error {
-
 	volumeList, err := getFilteredVolumeList(
 		ctx,
 		func(volume directcsi.DirectCSIVolume) bool {
@@ -150,10 +149,10 @@ func listVolumes(ctx context.Context, args []string) error {
 			}
 		}
 		row := []interface{}{
-			volume.Name, //VOLUME
-			printableBytes(volume.Status.TotalCapacity),                        //CAPACITY
-			volume.Status.NodeName,                                             //SERVER
-			driveName(getLabelValue(&volume, string(utils.DrivePathLabelKey))), //DRIVE
+			volume.Name, // VOLUME
+			printableBytes(volume.Status.TotalCapacity),                        // CAPACITY
+			volume.Status.NodeName,                                             // SERVER
+			driveName(getLabelValue(&volume, string(utils.DrivePathLabelKey))), // DRIVE
 			printableString(volume.Labels[directcsi.Group+"/pod.name"]),
 			printableString(volume.Labels[directcsi.Group+"/pod.namespace"]),
 			msg,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/jedib0t/go-pretty/v6 v6.0.5
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
 	github.com/minio/sha256-simd v1.0.0
@@ -74,7 +73,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/klauspost/cpuid/v2 v2.0.4 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,7 +92,6 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -346,8 +345,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -1042,7 +1039,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -1059,7 +1055,6 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=

--- a/pkg/apis/direct.csi.min.io/v1beta4/drive_matcher.go
+++ b/pkg/apis/direct.csi.min.io/v1beta4/drive_matcher.go
@@ -86,7 +86,7 @@ func ToDriveStatus(value string) (driveStatus DriveStatus, err error) {
 	}
 }
 
-//DriveStatusListToStrings maps drives list status to slice of string
+// DriveStatusListToStrings maps drives list status to slice of string
 func DriveStatusListToStrings(driveStatusList []DriveStatus) (slice []string) {
 	for _, driveStatus := range driveStatusList {
 		slice = append(slice, string(driveStatus))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -83,7 +83,7 @@ func getKubeConfig() (*rest.Config, string, error) {
 		if err != nil {
 			klog.Infof("could not find home dir: %v", err)
 		}
-		kubeConfig = filepath.Join(home, ".kube", "config")
+		kubeConfig = path.Join(home, ".kube", "config")
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)

--- a/pkg/client/drive.go
+++ b/pkg/client/drive.go
@@ -163,7 +163,8 @@ func CreateDrive(ctx context.Context, drive *directcsi.DirectCSIDrive) error {
 func DeleteDrive(
 	ctx context.Context,
 	drive *directcsi.DirectCSIDrive,
-	force bool) error {
+	force bool,
+) error {
 	var err error
 	if drive.Status.DriveStatus != directcsi.DriveStatusTerminating {
 		drive.Status.DriveStatus = directcsi.DriveStatusTerminating

--- a/pkg/client/interface_test.go
+++ b/pkg/client/interface_test.go
@@ -601,6 +601,7 @@ func getFakeDirectCSIVolumeAdapter(drive runtime.Object, i int, version string, 
 	}
 	return &directCSIVolumeInterface{*fakeDirecCSIClient}
 }
+
 func TestGetVolume(t *testing.T) {
 	testCases := []struct {
 		backendVersion string
@@ -687,7 +688,6 @@ func TestListVolume(t *testing.T) {
 			t.Fatalf("case %v: result: expected: %v, got: %v", i+1, expectedGV, volumeList.GetObjectKind().GroupVersionKind().GroupVersion())
 		}
 	}
-
 }
 
 func TestCreateVolume(t *testing.T) {

--- a/pkg/client/scheme.go
+++ b/pkg/client/scheme.go
@@ -34,6 +34,7 @@ var Codecs = serializer.NewCodecFactory(Scheme)
 
 // ParameterCodec is new parameter codec of new runtime scheme.
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
+
 var localSchemeBuilder = runtime.SchemeBuilder{
 	kubernetesscheme.AddToScheme,
 	directcsi.AddToScheme,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -232,7 +232,6 @@ func TestCreateAndDeleteVolumeRPCs(t *testing.T) {
 }
 
 func TestAbnormalDeleteVolume(t1 *testing.T) {
-
 	testVolumeObjects := []runtime.Object{
 		&directcsi.DirectCSIVolume{
 			TypeMeta: utils.DirectCSIVolumeTypeMeta(),

--- a/pkg/controller/validation-handlers.go
+++ b/pkg/controller/validation-handlers.go
@@ -34,8 +34,7 @@ const (
 	xfsFileSystem = "xfs"
 )
 
-type validationHandler struct {
-}
+type validationHandler struct{}
 
 func parseAdmissionReview(req *http.Request) (admissionv1.AdmissionReview, error) {
 	var body []byte
@@ -177,7 +176,6 @@ func validateRequestedFormat(directCSIDrive directcsi.DirectCSIDrive, admissionR
    - Check if force option is set if the drive has an existing filesystem or mountpoint
 */
 func (vh *validationHandler) validateDrive(w http.ResponseWriter, r *http.Request) {
-
 	admissionReview, err := parseAdmissionReview(r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to parse the body: %v", err), http.StatusBadRequest)
@@ -209,7 +207,6 @@ func (vh *validationHandler) validateDrive(w http.ResponseWriter, r *http.Reques
 
 // To-Do: Volume updates other than conditions shouldn't be allowed.
 func (vh *validationHandler) validateVolume(w http.ResponseWriter, r *http.Request) {
-
 	admissionReview, err := parseAdmissionReview(r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to parse the body: %v", err), http.StatusBadRequest)

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -33,9 +33,7 @@ import (
 
 type migrateFunc func(object *unstructured.Unstructured, toVersion string) error
 
-var (
-	errUnsupportedCRDKind = errors.New("unsupported CRD Kind")
-)
+var errUnsupportedCRDKind = errors.New("unsupported CRD Kind")
 
 func convertDriveCRD(Object *unstructured.Unstructured, toVersion string) (*unstructured.Unstructured, metav1.Status) {
 	convertedObject := Object.DeepCopy()

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -137,7 +137,6 @@ request:
 	if directCSIDrive.Status.AccessTier != directv1beta1.AccessTierUnknown {
 		t.Errorf("expected status.accessTier = %v, actual status.accessTier = %v", directv1beta1.AccessTierUnknown, directCSIDrive.Status.AccessTier)
 	}
-
 }
 
 func TestV1alpha1ToV1beta2VolumeUpgrade(t *testing.T) {
@@ -264,7 +263,6 @@ request:
 	if !utils.IsCondition(directCSIVolume.Status.Conditions, string(directv1beta2.DirectCSIVolumeConditionReady), metav1.ConditionTrue, string(directv1beta2.DirectCSIVolumeReasonReady), "") {
 		t.Errorf("unexpected status.conditions = %v", directCSIVolume.Status.Conditions)
 	}
-
 }
 
 func TestV1alpha1ToV1beta4VolumeUpgrade(t *testing.T) {
@@ -391,7 +389,6 @@ request:
 	if !utils.IsCondition(directCSIVolume.Status.Conditions, string(directv1beta4.DirectCSIVolumeConditionReady), metav1.ConditionTrue, string(directv1beta4.DirectCSIVolumeReasonReady), "") {
 		t.Errorf("unexpected status.conditions = %v", directCSIVolume.Status.Conditions)
 	}
-
 }
 
 func TestV1beta1ToV1beta2DriveUpgrade(t *testing.T) {
@@ -806,7 +803,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta4"},
+				Version: "v1beta4",
+			},
 		},
 		// upgrade drive v1beta1 => v1beta3
 		{
@@ -848,7 +846,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 		// upgrade drive v1beta2 => v1beta4
 		{
@@ -892,7 +891,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta4"},
+				Version: "v1beta4",
+			},
 		},
 		// upgrade drive v1beta2 => v1beta3
 		{
@@ -934,7 +934,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 
 		// downgrade drive v1beta4 => v1beta1
@@ -979,7 +980,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta1"},
+				Version: "v1beta1",
+			},
 		},
 		// downgrade drive v1beta4 => v1beta2
 		{
@@ -1023,7 +1025,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta2"},
+				Version: "v1beta2",
+			},
 		},
 		// downgrade drive v1beta4 => v1beta3
 		{
@@ -1067,7 +1070,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 
 		// downgrade drive v1beta3 => v1beta1
@@ -1110,7 +1114,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta1"},
+				Version: "v1beta1",
+			},
 		},
 		// downgrade drive v1beta3 => v1beta2
 		{
@@ -1152,7 +1157,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta2"},
+				Version: "v1beta2",
+			},
 		},
 
 		// upgrage volume v1beta1 => v1beta4
@@ -1189,7 +1195,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta4"},
+				Version: "v1beta4",
+			},
 		},
 		// upgrage volume v1beta2 => v1beta4
 		{
@@ -1225,7 +1232,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta4"},
+				Version: "v1beta4",
+			},
 		},
 		// upgrage volume v1beta1 => v1beta3
 		{
@@ -1261,7 +1269,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 		// upgrage volume v1beta2 => v1beta3
 		{
@@ -1297,7 +1306,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 		// downgrade volume v1beta4 => v1beta1
 		{
@@ -1333,7 +1343,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta1"},
+				Version: "v1beta1",
+			},
 		},
 		// downgrage volume v1beta4 => v1beta2
 		{
@@ -1369,7 +1380,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta2"},
+				Version: "v1beta2",
+			},
 		},
 		// downgrage volume v1beta4 => v1beta3
 		{
@@ -1405,7 +1417,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta3"},
+				Version: "v1beta3",
+			},
 		},
 
 		// downgrade volume v1beta3 => v1beta1
@@ -1442,7 +1455,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta1"},
+				Version: "v1beta1",
+			},
 		},
 		// downgrage volume v1beta3 => v1beta2
 		{
@@ -1478,7 +1492,8 @@ func TestMigrate(t *testing.T) {
 			},
 			groupVersion: schema.GroupVersion{
 				Group:   "direct.csi.min.io",
-				Version: "v1beta2"},
+				Version: "v1beta2",
+			},
 		},
 	}
 

--- a/pkg/converter/drive_downgrade.go
+++ b/pkg/converter/drive_downgrade.go
@@ -77,7 +77,6 @@ func downgradeDriveObject(object *unstructured.Unstructured, toVersion string) e
 }
 
 func driveDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta1DirectCSIDrive directv1beta1.DirectCSIDrive
@@ -103,7 +102,6 @@ func driveDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) er
 }
 
 func driveDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta2DirectCSIDrive directv1beta2.DirectCSIDrive
@@ -129,7 +127,6 @@ func driveDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) err
 }
 
 func driveDowngradeV1Beta3ToV1Beta2(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta3DirectCSIDrive directv1beta3.DirectCSIDrive
@@ -155,7 +152,6 @@ func driveDowngradeV1Beta3ToV1Beta2(unstructured *unstructured.Unstructured) err
 }
 
 func driveDowngradeV1Beta4ToV1Beta3(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta4DirectCSIDrive directv1beta4.DirectCSIDrive

--- a/pkg/converter/drive_upgrade.go
+++ b/pkg/converter/drive_upgrade.go
@@ -17,6 +17,7 @@
 package converter
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -46,7 +47,7 @@ func convertV1Beta1V1Beta2DeviceName(devName string) string {
 			sys.DirectCSIPartitionInfix,
 			sys.HostPartitionInfix,
 		)
-		return filepath.Join(sys.HostDevRoot, name)
+		return path.Join(sys.HostDevRoot, name)
 	}
 }
 
@@ -98,7 +99,6 @@ func upgradeDriveObject(object *unstructured.Unstructured, toVersion string) err
 }
 
 func driveUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1alpha1DirectCSIDrive directv1alpha1.DirectCSIDrive
@@ -126,7 +126,6 @@ func driveUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) erro
 }
 
 func driveUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta1DirectCSIDrive directv1beta1.DirectCSIDrive
@@ -161,7 +160,6 @@ func driveUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) error
 }
 
 func driveUpgradeV1Beta2ToV1Beta3(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta2DirectCSIDrive directv1beta2.DirectCSIDrive
@@ -196,7 +194,6 @@ func driveUpgradeV1Beta2ToV1Beta3(unstructured *unstructured.Unstructured) error
 }
 
 func driveUpgradeV1Beta3ToV1Beta4(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta3DirectCSIDrive directv1beta3.DirectCSIDrive

--- a/pkg/converter/framework.go
+++ b/pkg/converter/framework.go
@@ -69,7 +69,6 @@ func conversionResponseFailureWithMessagef(msg string, params ...interface{}) *v
 			Status:  metav1.StatusFailure,
 		},
 	}
-
 }
 
 func statusErrorWithMessage(msg string, params ...interface{}) metav1.Status {
@@ -170,11 +169,13 @@ type mediaType struct {
 	Type, SubType string
 }
 
-var scheme = runtime.NewScheme()
-var serializers = map[mediaType]runtime.Serializer{
-	{"application", "json"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{}),
-	{"application", "yaml"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true}),
-}
+var (
+	scheme      = runtime.NewScheme()
+	serializers = map[mediaType]runtime.Serializer{
+		{"application", "json"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{}),
+		{"application", "yaml"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true}),
+	}
+)
 
 func getInputSerializer(contentType string) runtime.Serializer {
 	parts := strings.SplitN(contentType, "/", 2)

--- a/pkg/converter/volume_downgrade.go
+++ b/pkg/converter/volume_downgrade.go
@@ -77,7 +77,6 @@ func downgradeVolumeObject(object *unstructured.Unstructured, toVersion string) 
 }
 
 func volumeDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta1DirectCSIVolume directv1beta1.DirectCSIVolume
@@ -103,7 +102,6 @@ func volumeDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) e
 }
 
 func volumeDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta2DirectCSIVolume directv1beta2.DirectCSIVolume
@@ -129,7 +127,6 @@ func volumeDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) er
 }
 
 func volumeDowngradeV1Beta3ToV1Beta2(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta3DirectCSIVolume directv1beta3.DirectCSIVolume
@@ -155,7 +152,6 @@ func volumeDowngradeV1Beta3ToV1Beta2(unstructured *unstructured.Unstructured) er
 }
 
 func volumeDowngradeV1Beta4ToV1Beta3(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta4DirectCSIVolume directv1beta4.DirectCSIVolume

--- a/pkg/converter/volume_upgrade.go
+++ b/pkg/converter/volume_upgrade.go
@@ -80,7 +80,6 @@ func upgradeVolumeObject(object *unstructured.Unstructured, toVersion string) er
 }
 
 func volumeUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1alpha1DirectCSIVolume directv1alpha1.DirectCSIVolume
@@ -133,7 +132,6 @@ func volumeUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) err
 }
 
 func volumeUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta1DirectCSIVolume directv1beta1.DirectCSIVolume
@@ -165,7 +163,6 @@ func volumeUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) erro
 }
 
 func volumeUpgradeV1Beta2ToV1Beta3(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta2DirectCSIVolume directv1beta2.DirectCSIVolume
@@ -197,7 +194,6 @@ func volumeUpgradeV1Beta2ToV1Beta3(unstructured *unstructured.Unstructured) erro
 }
 
 func volumeUpgradeV1Beta3ToV1Beta4(unstructured *unstructured.Unstructured) error {
-
 	unstructuredObject := unstructured.Object
 
 	var v1beta3DirectCSIVolume directv1beta3.DirectCSIVolume

--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
@@ -130,7 +130,7 @@ func (handler *driveEventHandler) handleUpdate(ctx context.Context, drive *direc
 	case errNotMounted:
 		return handler.mountDrive(ctx, drive, false)
 	case errInvalidMountOptions:
-		if drive.Status.Mountpoint == filepath.Join(sys.MountRoot, drive.Status.FilesystemUUID) {
+		if drive.Status.Mountpoint == path.Join(sys.MountRoot, drive.Status.FilesystemUUID) {
 			// do not try to umount a legacy mount (fsuuid mounts)
 			return nil
 		}
@@ -141,7 +141,6 @@ func (handler *driveEventHandler) handleUpdate(ctx context.Context, drive *direc
 		}
 		return err
 	}
-
 }
 
 func (handler *driveEventHandler) delete(ctx context.Context, drive *directcsi.DirectCSIDrive) error {
@@ -149,7 +148,7 @@ func (handler *driveEventHandler) delete(ctx context.Context, drive *directcsi.D
 }
 
 func (handler *driveEventHandler) format(ctx context.Context, drive *directcsi.DirectCSIDrive) (err error) {
-	target := filepath.Join(sys.MountRoot, drive.Name)
+	target := path.Join(sys.MountRoot, drive.Name)
 	mounted, err := handler.isMounted(target)
 	if err != nil {
 		klog.Error(err)
@@ -188,7 +187,7 @@ func (handler *driveEventHandler) format(ctx context.Context, drive *directcsi.D
 	}
 	// mount the drive
 	if err == nil {
-		target := filepath.Join(sys.MountRoot, drive.Name)
+		target := path.Join(sys.MountRoot, drive.Name)
 		err = handler.mountDevice(device, target, []string{})
 		if err != nil {
 			klog.Errorf("failed to mount drive %s; %w", drive.Name, err)
@@ -266,7 +265,7 @@ func (handler *driveEventHandler) mountDrive(ctx context.Context, drive *directc
 		}
 	}
 	if err == nil {
-		target := filepath.Join(sys.MountRoot, drive.Name)
+		target := path.Join(sys.MountRoot, drive.Name)
 		err = handler.mountDevice(device, target, []string{})
 		if err != nil {
 			klog.Errorf("failed to mount drive %s; %w", drive.Name, err)

--- a/pkg/drive/drive_test.go
+++ b/pkg/drive/drive_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -122,10 +123,10 @@ func TestFormatHander(t *testing.T) {
 	var getDeviceCalled, isMountedCalled, statCalled, makeFSCalled, mountDeviceCalled bool
 	dl.isMounted = func(target string) (bool, error) {
 		isMountedCalled = true
-		if target != filepath.Join(sys.MountRoot, testDrive.Name) {
+		if target != path.Join(sys.MountRoot, testDrive.Name) {
 			return false, fmt.Errorf(
 				"expected target %s but got %s",
-				filepath.Join(sys.MountRoot, testDrive.Name),
+				path.Join(sys.MountRoot, testDrive.Name),
 				target,
 			)
 		}
@@ -169,8 +170,8 @@ func TestFormatHander(t *testing.T) {
 		if device != testDrive.Status.Path {
 			return fmt.Errorf("expected device %s but got %s", testDrive.Status.Path, device)
 		}
-		if target != filepath.Join(sys.MountRoot, testDrive.Name) {
-			return fmt.Errorf("expected target %s but got %s", filepath.Join(sys.MountRoot, testDrive.Name), target)
+		if target != path.Join(sys.MountRoot, testDrive.Name) {
+			return fmt.Errorf("expected target %s but got %s", path.Join(sys.MountRoot, testDrive.Name), target)
 		}
 		return nil
 	}
@@ -261,10 +262,10 @@ func TestFormatHanderWithError(t *testing.T) {
 	var getDeviceCalled, isMountedCalled, statCalled, makeFSCalled bool
 	dl.isMounted = func(target string) (bool, error) {
 		isMountedCalled = true
-		if target != filepath.Join(sys.MountRoot, testDrive.Name) {
+		if target != path.Join(sys.MountRoot, testDrive.Name) {
 			return false, fmt.Errorf(
 				"expected target %s but got %s",
-				filepath.Join(sys.MountRoot, testDrive.Name),
+				path.Join(sys.MountRoot, testDrive.Name),
 				target,
 			)
 		}
@@ -579,8 +580,8 @@ func TestMountDriveHander(t *testing.T) {
 		if device != testDrive.Status.Path {
 			return fmt.Errorf("expected device %s but got %s", testDrive.Status.Path, device)
 		}
-		if target != filepath.Join(sys.MountRoot, testDrive.Name) {
-			return fmt.Errorf("expected target %s but got %s", filepath.Join(sys.MountRoot, testDrive.Name), target)
+		if target != path.Join(sys.MountRoot, testDrive.Name) {
+			return fmt.Errorf("expected target %s but got %s", path.Join(sys.MountRoot, testDrive.Name), target)
 		}
 		return nil
 	}
@@ -714,8 +715,8 @@ func TestRemountDriveHander(t *testing.T) {
 		if device != testDrive.Status.Path {
 			return fmt.Errorf("expected device %s but got %s", testDrive.Status.Path, device)
 		}
-		if target != filepath.Join(sys.MountRoot, testDrive.Name) {
-			return fmt.Errorf("expected target %s but got %s", filepath.Join(sys.MountRoot, testDrive.Name), target)
+		if target != path.Join(sys.MountRoot, testDrive.Name) {
+			return fmt.Errorf("expected target %s but got %s", path.Join(sys.MountRoot, testDrive.Name), target)
 		}
 		return nil
 	}

--- a/pkg/drive/utils.go
+++ b/pkg/drive/utils.go
@@ -19,6 +19,7 @@ package drive
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -68,7 +69,6 @@ func getFSUUIDFromDrive(drive *directcsi.DirectCSIDrive) string {
 //            Else, return errNotMounted
 // ----------------------------------------------------------------------------
 func VerifyHostStateForDrive(drive *directcsi.DirectCSIDrive) error {
-
 	if utils.IsV1Beta1Drive(drive) && drive.Status.MajorNumber == uint32(0) && drive.Status.MinorNumber == uint32(0) {
 		klog.V(4).Infof("waiting for drive %s to be upgraded from v1beta1", drive.Status.Path)
 		return errDriveNotUpgraded
@@ -118,7 +118,7 @@ func VerifyHostStateForDrive(drive *directcsi.DirectCSIDrive) error {
 
 	if drive.Status.DriveStatus == directcsi.DriveStatusInUse ||
 		drive.Status.DriveStatus == directcsi.DriveStatusReady {
-		target := filepath.Join(sys.MountRoot, drive.Name)
+		target := path.Join(sys.MountRoot, drive.Name)
 		mounted, err := mount.IsMounted(target)
 		if err != nil {
 			return err

--- a/pkg/ellipsis/ellipsis_test.go
+++ b/pkg/ellipsis/ellipsis_test.go
@@ -44,9 +44,11 @@ func TestExpand(t *testing.T) {
 		// Valid case- Start with ellipsis
 		{"{a...c}p{0...2}9", []string{"ap09", "ap19", "ap29", "bp09", "bp19", "bp29", "cp09", "cp19", "cp29"}, false},
 		// Valid case- Start with ellipsis
-		{"{a...c}p{0...2}9{d...a}", []string{"ap09a", "ap09b", "ap09c", "ap09d", "ap19a", "ap19b", "ap19c", "ap19d", "ap29a",
+		{"{a...c}p{0...2}9{d...a}", []string{
+			"ap09a", "ap09b", "ap09c", "ap09d", "ap19a", "ap19b", "ap19c", "ap19d", "ap29a",
 			"ap29b", "ap29c", "ap29d", "bp09a", "bp09b", "bp09c", "bp09d", "bp19a", "bp19b", "bp19c", "bp19d", "bp29a",
-			"bp29b", "bp29c", "bp29d", "cp09a", "cp09b", "cp09c", "cp09d", "cp19a", "cp19b", "cp19c", "cp19d", "cp29a", "cp29b", "cp29c", "cp29d"}, false},
+			"bp29b", "bp29c", "bp29d", "cp09a", "cp09b", "cp09c", "cp09d", "cp19a", "cp19b", "cp19c", "cp19d", "cp29a", "cp29b", "cp29c", "cp29d",
+		}, false},
 		// Valid case- Start with non-ellipsis
 		{"abc", []string{"abc"}, false},
 		// Valid case- Start with non-ellipsis
@@ -58,13 +60,15 @@ func TestExpand(t *testing.T) {
 		// Valid case- ellipsis start with two digit
 		{"a{12...20}x", []string{"a12x", "a13x", "a14x", "a15x", "a16x", "a17x", "a18x", "a19x", "a20x"}, false},
 		// Valid case - ellipsis start with two digit end with two digits
-		{"ax{ab...dx}y", []string{"axaby", "axacy", "axady", "axaey", "axafy", "axagy", "axahy", "axaiy", "axajy", "axaky",
+		{"ax{ab...dx}y", []string{
+			"axaby", "axacy", "axady", "axaey", "axafy", "axagy", "axahy", "axaiy", "axajy", "axaky",
 			"axaly", "axamy", "axany", "axaoy", "axapy", "axaqy", "axary", "axasy", "axaty", "axauy", "axavy", "axawy", "axaxy", "axayy", "axazy",
 			"axbay", "axbby", "axbcy", "axbdy", "axbey", "axbfy", "axbgy", "axbhy", "axbiy", "axbjy", "axbky", "axbly", "axbmy", "axbny", "axboy",
 			"axbpy", "axbqy", "axbry", "axbsy", "axbty", "axbuy", "axbvy", "axbwy", "axbxy", "axbyy", "axbzy", "axcay", "axcby", "axccy", "axcdy",
 			"axcey", "axcfy", "axcgy", "axchy", "axciy", "axcjy", "axcky", "axcly", "axcmy", "axcny", "axcoy", "axcpy", "axcqy", "axcry", "axcsy",
 			"axcty", "axcuy", "axcvy", "axcwy", "axcxy", "axcyy", "axczy", "axday", "axdby", "axdcy", "axddy", "axdey", "axdfy", "axdgy", "axdhy",
-			"axdiy", "axdjy", "axdky", "axdly", "axdmy", "axdny", "axdoy", "axdpy", "axdqy", "axdry", "axdsy", "axdty", "axduy", "axdvy", "axdwy", "axdxy"}, false},
+			"axdiy", "axdjy", "axdky", "axdly", "axdmy", "axdny", "axdoy", "axdpy", "axdqy", "axdry", "axdsy", "axdty", "axduy", "axdvy", "axdwy", "axdxy",
+		}, false},
 		// Invalid case with one dot
 		{"a{a.c}p", nil, true},
 		// Invalid case - two dots

--- a/pkg/installer/conversion_secret.go
+++ b/pkg/installer/conversion_secret.go
@@ -29,7 +29,6 @@ import (
 )
 
 func createOrUpdateConversionKeyPairSecret(ctx context.Context, publicCertBytes, privateKeyBytes []byte, c *Config) error {
-
 	secretsClient := client.GetKubeClient().CoreV1().Secrets(c.namespace())
 
 	getCertsDataMap := func() map[string][]byte {
@@ -77,7 +76,6 @@ func createOrUpdateConversionKeyPairSecret(ctx context.Context, publicCertBytes,
 }
 
 func createOrUpdateConversionCACertSecret(ctx context.Context, caCertBytes []byte, c *Config) error {
-
 	secretsClient := client.GetKubeClient().CoreV1().Secrets(c.namespace())
 
 	getCertsDataMap := func() map[string][]byte {

--- a/pkg/installer/csidriver.go
+++ b/pkg/installer/csidriver.go
@@ -30,9 +30,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var (
-	errCSIDriverVersionUnsupported = errors.New("Unsupported CSIDriver version found")
-)
+var errCSIDriverVersionUnsupported = errors.New("Unsupported CSIDriver version found")
 
 func createCSIDriver(ctx context.Context, c *Config) error {
 	podInfoOnMount := true

--- a/pkg/installer/daemonset.go
+++ b/pkg/installer/daemonset.go
@@ -19,7 +19,7 @@ package installer
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/utils"
@@ -49,14 +49,12 @@ func uninstallDaemonsetDefault(ctx context.Context, c *Config) error {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-
 	}
 	klog.Infof("'%s' daemonset deleted", utils.Bold(c.Identity))
 	return nil
 }
 
 func createDaemonSet(ctx context.Context, c *Config) error {
-
 	privileged := true
 	securityContext := &corev1.SecurityContext{Privileged: &privileged}
 
@@ -106,7 +104,7 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 		Containers: []corev1.Container{
 			{
 				Name:  nodeDriverRegistrarContainerName,
-				Image: filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getNodeDriverRegistrarImage()),
+				Image: path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getNodeDriverRegistrarImage()),
 				Args: []string{
 					fmt.Sprintf("--v=%d", logLevel),
 					"--csi-address=unix:///csi/csi.sock",
@@ -133,7 +131,7 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 			},
 			{
 				Name:  directCSIContainerName,
-				Image: filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
+				Image: path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
 				Args: func() []string {
 					args := []string{
 						fmt.Sprintf("--identity=%s", c.daemonsetName()),
@@ -203,7 +201,7 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 			},
 			{
 				Name:  livenessProbeContainerName,
-				Image: filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getLivenessProbeImage()),
+				Image: path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getLivenessProbeImage()),
 				Args: []string{
 					"--csi-address=/csi/csi.sock",
 					"--health-port=9898",
@@ -236,7 +234,7 @@ func createDaemonSet(ctx context.Context, c *Config) error {
 
 		podSpec.Containers = append(podSpec.Containers, corev1.Container{
 			Name:            directPVDriveDiscoveryContainerName,
-			Image:           filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
+			Image:           path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
 			Args:            args,
 			SecurityContext: securityContext,
 			Env: []corev1.EnvVar{

--- a/pkg/installer/default.go
+++ b/pkg/installer/default.go
@@ -34,33 +34,43 @@ func newDefaultInstaller(config *Config) *defaultInstaller {
 func (v *defaultInstaller) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *defaultInstaller) installValidationRules(ctx context.Context) error {
 func (v *defaultInstaller) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *defaultInstaller) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/deployment.go
+++ b/pkg/installer/deployment.go
@@ -19,7 +19,7 @@ package installer
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/utils"
@@ -33,7 +33,6 @@ import (
 )
 
 func createControllerSecret(ctx context.Context, publicCertBytes, privateKeyBytes []byte, c *Config) error {
-
 	getCertsDataMap := func() map[string][]byte {
 		mp := make(map[string][]byte)
 		mp[privateKeyFileName] = privateKeyBytes
@@ -132,7 +131,7 @@ func createDeployment(ctx context.Context, c *Config) error {
 		Containers: []corev1.Container{
 			{
 				Name:  csiProvisionerContainerName,
-				Image: filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getCSIProvisionerImage()),
+				Image: path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.getCSIProvisionerImage()),
 				Args: []string{
 					fmt.Sprintf("--v=%d", logLevel),
 					"--timeout=300s",
@@ -171,7 +170,7 @@ func createDeployment(ctx context.Context, c *Config) error {
 			},
 			{
 				Name:  directCSIContainerName,
-				Image: filepath.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
+				Image: path.Join(c.DirectCSIContainerRegistry, c.DirectCSIContainerOrg, c.DirectCSIContainerImage),
 				Args: []string{
 					fmt.Sprintf("-v=%d", logLevel),
 					fmt.Sprintf("--identity=%s", c.deploymentName()),

--- a/pkg/installer/psp.go
+++ b/pkg/installer/psp.go
@@ -31,7 +31,6 @@ import (
 )
 
 func createPodSecurityPolicy(ctx context.Context, i *Config) error {
-
 	pspObj := &policy.PodSecurityPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "policy/v1beta1",
@@ -146,7 +145,6 @@ func installPSPDefault(ctx context.Context, i *Config) error {
 
 	klog.Infof("pod security policy is not supported in your kubernetes")
 	return nil
-
 }
 
 func uninstallPSPDefault(ctx context.Context, i *Config) error {

--- a/pkg/installer/register.go
+++ b/pkg/installer/register.go
@@ -38,9 +38,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var (
-	errEmptyCABundle = errors.New("CA bundle is empty")
-)
+var errEmptyCABundle = errors.New("CA bundle is empty")
 
 func parseSingleKubeNativeFromBytes(data []byte) (runtime.Object, error) {
 	obj := map[string]interface{}{}
@@ -153,7 +151,6 @@ func syncCRD(ctx context.Context, existingCRD *apiextensions.CustomResourceDefin
 }
 
 func setConversionWebhook(ctx context.Context, crdObj *apiextensions.CustomResourceDefinition, c *Config) error {
-
 	getServiceRef := func() *apiextensions.ServiceReference {
 		path := func() string {
 			switch crdObj.Name {

--- a/pkg/installer/storageclass.go
+++ b/pkg/installer/storageclass.go
@@ -31,9 +31,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var (
-	errStorageClassVersionUnsupported = errors.New("Unsupported StorageClass version found")
-)
+var errStorageClassVersionUnsupported = errors.New("Unsupported StorageClass version found")
 
 func installStorageClassDefault(ctx context.Context, c *Config) error {
 	if err := createStorageClass(ctx, c, c.storageClassNameDirectCSI()); err != nil {

--- a/pkg/installer/utils.go
+++ b/pkg/installer/utils.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -61,7 +61,7 @@ func newRandomString(length int) string {
 }
 
 func newDirectCSIPluginsSocketDir(kubeletDir, name string) string {
-	return filepath.Join(kubeletDir, "plugins", utils.SanitizeKubeResourceName(name))
+	return path.Join(kubeletDir, "plugins", utils.SanitizeKubeResourceName(name))
 }
 
 func getConversionWebhookDNSName(identity string) string {

--- a/pkg/installer/v1dot18.go
+++ b/pkg/installer/v1dot18.go
@@ -34,33 +34,43 @@ func newV1Dot18(config *Config) *v1dot18 {
 func (v *v1dot18) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot18) installValidationRules(ctx context.Context) error {
 func (v *v1dot18) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot18) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/v1dot19.go
+++ b/pkg/installer/v1dot19.go
@@ -34,33 +34,43 @@ func newV1Dot19(config *Config) *v1dot19 {
 func (v *v1dot19) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot19) installValidationRules(ctx context.Context) error {
 func (v *v1dot19) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot19) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/v1dot20.go
+++ b/pkg/installer/v1dot20.go
@@ -34,33 +34,43 @@ func newV1Dot20(config *Config) *v1dot20 {
 func (v *v1dot20) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot20) installValidationRules(ctx context.Context) error {
 func (v *v1dot20) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot20) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/v1dot21.go
+++ b/pkg/installer/v1dot21.go
@@ -34,33 +34,43 @@ func newV1Dot21(config *Config) *v1dot21 {
 func (v *v1dot21) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot21) installValidationRules(ctx context.Context) error {
 func (v *v1dot21) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot21) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/v1dot22.go
+++ b/pkg/installer/v1dot22.go
@@ -34,33 +34,43 @@ func newV1Dot22(config *Config) *v1dot22 {
 func (v *v1dot22) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot22) installValidationRules(ctx context.Context) error {
 func (v *v1dot22) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot22) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/v1dot23.go
+++ b/pkg/installer/v1dot23.go
@@ -34,33 +34,43 @@ func newV1Dot23(config *Config) *v1dot23 {
 func (v *v1dot23) installNS(ctx context.Context) error {
 	return installNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installRBAC(ctx context.Context) error {
 	return installRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installPSP(ctx context.Context) error {
 	return installPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installConversionSecret(ctx context.Context) error {
 	return installConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installCRD(ctx context.Context) error {
 	return installCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installCSIDriver(ctx context.Context) error {
 	return installCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installStorageClass(ctx context.Context) error {
 	return installStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installService(ctx context.Context) error {
 	return installServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installDaemonset(ctx context.Context) error {
 	return installDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installDeployment(ctx context.Context) error {
 	return installDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) installValidationRules(ctx context.Context) error {
 	return installValidationRulesDefault(ctx, v.Config)
 }
@@ -69,33 +79,43 @@ func (v *v1dot23) installValidationRules(ctx context.Context) error {
 func (v *v1dot23) uninstallNS(ctx context.Context) error {
 	return uninstallNSDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallRBAC(ctx context.Context) error {
 	return uninstallRBACDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallPSP(ctx context.Context) error {
 	return uninstallPSPDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallConversionSecret(ctx context.Context) error {
 	return uninstallConversionSecretDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallCRD(ctx context.Context) error {
 	return uninstallCRDDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallCSIDriver(ctx context.Context) error {
 	return uninstallCSIDriverDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallStorageClass(ctx context.Context) error {
 	return uninstallStorageClassDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallService(ctx context.Context) error {
 	return uninstallServiceDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallDaemonset(ctx context.Context) error {
 	return uninstallDaemonsetDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallDeployment(ctx context.Context) error {
 	return uninstallDeploymentDefault(ctx, v.Config)
 }
+
 func (v *v1dot23) uninstallValidationRules(ctx context.Context) error {
 	return uninstallValidationRulesDefault(ctx, v.Config)
 }

--- a/pkg/installer/validationrules.go
+++ b/pkg/installer/validationrules.go
@@ -41,7 +41,6 @@ func registerDriveValidationRules(ctx context.Context, c *Config) error {
 }
 
 func getDriveValidatingWebhookConfig(c *Config) admissionv1.ValidatingWebhookConfiguration {
-
 	getServiceRef := func() *admissionv1.ServiceReference {
 		path := "/validatedrive"
 		return &admissionv1.ServiceReference{
@@ -56,7 +55,6 @@ func getDriveValidatingWebhookConfig(c *Config) admissionv1.ValidatingWebhookCon
 			Service:  getServiceRef(),
 			CABundle: c.validationWebhookCaBundle,
 		}
-
 	}
 
 	getValidationRules := func() []admissionv1.RuleWithOperations {

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -46,9 +46,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var (
-	errLeaderElectionDied = errors.New("leaderelection died")
-)
+var errLeaderElectionDied = errors.New("leaderelection died")
 
 func getNamespace() string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -56,7 +56,8 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 func (c *metricsCollector) volumeStatsEmitter(
 	ctx context.Context,
 	ch chan<- prometheus.Metric,
-	volumeStatsGetter xfsVolumeStatsGetter) {
+	volumeStatsGetter xfsVolumeStatsGetter,
+) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 
@@ -85,7 +86,6 @@ func (c *metricsCollector) volumeStatsEmitter(
 }
 
 func metricsHandler(nodeID string) http.Handler {
-
 	registry := prometheus.NewRegistry()
 
 	mc, err := newMetricsCollector(nodeID)
@@ -108,5 +108,4 @@ func metricsHandler(nodeID string) http.Handler {
 				ErrorHandling: promhttp.ContinueOnError,
 			}),
 	)
-
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,7 +27,6 @@ import (
 
 // ServeMetrics starts metrics service.
 func ServeMetrics(ctx context.Context, nodeID string, port int) {
-
 	server := &http.Server{
 		Handler: metricsHandler(nodeID),
 	}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -65,7 +65,7 @@ func UnmountDevice(device string) error {
 
 // MountXFSDevice mounts device having XFS filesystem into target.
 func MountXFSDevice(device, target string, flags []string) error {
-	if err := os.MkdirAll(target, 0777); err != nil {
+	if err := os.MkdirAll(target, 0o777); err != nil {
 		return err
 	}
 	// mount with "noatime" by default

--- a/pkg/mount/probe_test.go
+++ b/pkg/mount/probe_test.go
@@ -259,7 +259,8 @@ func testProbeCast2Result() map[string][]MountInfo {
 			{MajorMinor: "7:5", MountPoint: "/snap/snapd/12159", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"},
 		},
 		"7:6": {
-			{MajorMinor: "7:6", MountPoint: "/snap/snapd/12057", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"}},
+			{MajorMinor: "7:6", MountPoint: "/snap/snapd/12057", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"},
+		},
 	}
 }
 
@@ -514,7 +515,8 @@ func testProbeCast3Result() map[string][]MountInfo {
 			{MajorMinor: "7:5", MountPoint: "/snap/snapd/12159", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"},
 		},
 		"7:6": {
-			{MajorMinor: "7:6", MountPoint: "/snap/snapd/12057", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"}},
+			{MajorMinor: "7:6", MountPoint: "/snap/snapd/12057", MountOptions: []string{"nodev", "relatime", "ro"}, fsType: "squashfs"},
+		},
 	}
 }
 

--- a/pkg/node/fake_node_server.go
+++ b/pkg/node/fake_node_server.go
@@ -37,12 +37,15 @@ type fakeXFS struct{}
 func (fxfs *fakeXFS) ID() string {
 	return ""
 }
+
 func (fxfs *fakeXFS) Type() string {
 	return "xfs"
 }
+
 func (fxfs *fakeXFS) TotalCapacity() uint64 {
 	return uint64(0)
 }
+
 func (fxfs *fakeXFS) FreeCapacity() uint64 {
 	return uint64(0)
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -76,8 +76,8 @@ type NodeServer struct { //revive:disable-line:exported
 // NewNodeServer creates node server.
 func NewNodeServer(ctx context.Context,
 	identity, nodeID, rack, zone, region string,
-	reflinkSupport bool, metricsPort int) (*NodeServer, error) {
-
+	reflinkSupport bool, metricsPort int,
+) (*NodeServer, error) {
 	config, err := client.GetKubeConfig()
 	if err != nil {
 		return &NodeServer{}, err

--- a/pkg/node/publish_unpublish.go
+++ b/pkg/node/publish_unpublish.go
@@ -41,7 +41,6 @@ const (
 )
 
 func parseVolumeContext(volumeContext map[string]string) (name, ns string, err error) {
-
 	parseValue := func(key string) (string, error) {
 		value, ok := volumeContext[key]
 		if !ok {
@@ -129,7 +128,7 @@ func (n *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err := os.MkdirAll(req.GetTargetPath(), 0755); err != nil {
+	if err := os.MkdirAll(req.GetTargetPath(), 0o755); err != nil {
 		return nil, err
 	}
 

--- a/pkg/node/stage_unstage.go
+++ b/pkg/node/stage_unstage.go
@@ -18,7 +18,7 @@ package node
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 
 	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
 	"github.com/minio/directpv/pkg/fs/xfs"
@@ -72,9 +72,9 @@ func (n *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	driveMountPoint := filepath.Join(sys.MountRoot, directCSIDrive.Name)
-	path := filepath.Join(driveMountPoint, vID)
-	if err := n.mkdirAll(path, 0755); err != nil {
+	driveMountPoint := path.Join(sys.MountRoot, directCSIDrive.Name)
+	path := path.Join(driveMountPoint, vID)
+	if err := n.mkdirAll(path, 0o755); err != nil {
 		return nil, err
 	}
 

--- a/pkg/node/stage_unstage_test.go
+++ b/pkg/node/stage_unstage_test.go
@@ -19,7 +19,7 @@ package node
 import (
 	"context"
 	"errors"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -127,7 +127,7 @@ func TestStageUnstageVolume(t *testing.T) {
 				},
 			},
 			Status: directcsi.DirectCSIDriveStatus{
-				Mountpoint:        filepath.Join(sys.MountRoot, testDriveName),
+				Mountpoint:        path.Join(sys.MountRoot, testDriveName),
 				NodeName:          testNodeName,
 				DriveStatus:       directcsi.DriveStatusInUse,
 				FreeCapacity:      mb50,
@@ -198,8 +198,8 @@ func TestStageUnstageVolume(t *testing.T) {
 	ns := createFakeNodeServer()
 	ns.directcsiClient = fakedirect.NewSimpleClientset(testObjects...)
 	directCSIClient := ns.directcsiClient.DirectV1beta4()
-	hostPath := filepath.Join(
-		filepath.Join(
+	hostPath := path.Join(
+		path.Join(
 			sys.MountRoot,
 			testDriveName,
 		),

--- a/pkg/node/uevent.go
+++ b/pkg/node/uevent.go
@@ -34,8 +34,8 @@ import (
 // RunDynamicDriveHandler starts the listener
 func RunDynamicDriveHandler(ctx context.Context,
 	identity, nodeID, rack, zone, region string,
-	disableUDevListener bool) error {
-
+	disableUDevListener bool,
+) error {
 	handler := &driveEventHandler{
 		nodeID: nodeID,
 		topology: map[string]string{

--- a/pkg/node/uevent_utils.go
+++ b/pkg/node/uevent_utils.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
@@ -165,11 +165,11 @@ func validateDrive(drive *directcsi.DirectCSIDrive, device *sys.Device) error {
 		}
 		// Verify drive mount and mountopts
 		if device.FirstMountPoint != "" {
-			if device.FirstMountPoint != filepath.Join(sys.MountRoot, drive.Name) &&
-				device.FirstMountPoint != filepath.Join(sys.MountRoot, drive.Status.FilesystemUUID) {
+			if device.FirstMountPoint != path.Join(sys.MountRoot, drive.Name) &&
+				device.FirstMountPoint != path.Join(sys.MountRoot, drive.Status.FilesystemUUID) {
 				err = multierr.Append(err, errInvalidDrive(
 					"Mountpoint",
-					filepath.Join(sys.MountRoot, drive.Name),
+					path.Join(sys.MountRoot, drive.Name),
 					device.FirstMountPoint))
 			}
 			if !mount.ValidDirectPVMountOpts(device.FirstMountOptions) {
@@ -263,7 +263,7 @@ func checkAndUpdateConditions(drive *directcsi.DirectCSIDrive, device *sys.Devic
 	case directcsi.DriveStatusAvailable:
 		// Check if formatting request succeeded, If so, update the status fields
 		if drive.Spec.RequestedFormat != nil {
-			if drive.Status.Mountpoint == filepath.Join(sys.MountRoot, drive.Name) {
+			if drive.Status.Mountpoint == path.Join(sys.MountRoot, drive.Name) {
 				drive.Finalizers = []string{directcsi.DirectCSIDriveFinalizerDataProtection}
 				drive.Status.DriveStatus = directcsi.DriveStatusReady
 				drive.Spec.RequestedFormat = nil

--- a/pkg/node/uevent_utils_test.go
+++ b/pkg/node/uevent_utils_test.go
@@ -19,7 +19,7 @@ package node
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"reflect"
 	"testing"
 
@@ -1355,7 +1355,7 @@ func TestSetDriveStatus(t *testing.T) {
 				LogicalBlockSize:  uint64(512),
 				PhysicalBlockSize: uint64(512),
 				Partition:         1,
-				FirstMountPoint:   filepath.Join(sys.MountRoot, "test-drive"),
+				FirstMountPoint:   path.Join(sys.MountRoot, "test-drive"),
 			},
 			drive: &directcsi.DirectCSIDrive{
 				TypeMeta: utils.DirectCSIDriveTypeMeta(),
@@ -1484,7 +1484,7 @@ func TestSetDriveStatus(t *testing.T) {
 					PartTableUUID:     "7e3bf265-0396-440b-88fd-dc2003505583",
 					PartTableType:     "gpt",
 					DriveStatus:       directcsi.DriveStatusReady,
-					Mountpoint:        filepath.Join(sys.MountRoot, "test-drive"),
+					Mountpoint:        path.Join(sys.MountRoot, "test-drive"),
 					Topology: map[string]string{
 						string(utils.TopologyDriverIdentity): "identity",
 						string(utils.TopologyDriverRack):     "rack",
@@ -1551,7 +1551,7 @@ func TestSetDriveStatus(t *testing.T) {
 				LogicalBlockSize:  uint64(512),
 				PhysicalBlockSize: uint64(512),
 				Partition:         1,
-				// FirstMountPoint:   filepath.Join(sys.MountRoot, "test-drive"),
+				// FirstMountPoint:   path.Join(sys.MountRoot, "test-drive"),
 			},
 			drive: &directcsi.DirectCSIDrive{
 				TypeMeta: utils.DirectCSIDriveTypeMeta(),
@@ -1592,7 +1592,7 @@ func TestSetDriveStatus(t *testing.T) {
 					PartTableUUID:     "7e3bf265-0396-440b-88fd-dc2003505583",
 					PartTableType:     "gpt",
 					DriveStatus:       directcsi.DriveStatusReleased,
-					Mountpoint:        filepath.Join(sys.MountRoot, "test-drive"),
+					Mountpoint:        path.Join(sys.MountRoot, "test-drive"),
 					Topology: map[string]string{
 						string(utils.TopologyDriverIdentity): "identity",
 						string(utils.TopologyDriverRack):     "rack",
@@ -2641,5 +2641,4 @@ func TestSyncVolumeLabels(t *testing.T) {
 			t.Fatalf("drive path label mismatch. expected: sdb1 got %s", value)
 		}
 	}
-
 }

--- a/pkg/sys/smart/nvme.go
+++ b/pkg/sys/smart/nvme.go
@@ -30,9 +30,7 @@ const (
 	nvmeAdminIdentify = 0x06
 )
 
-var (
-	nvmeIoctlAdminCmd = ioctl.Iowr('N', 0x41, unsafe.Sizeof(nvmePassthruCommand{}))
-)
+var nvmeIoctlAdminCmd = ioctl.Iowr('N', 0x41, unsafe.Sizeof(nvmePassthruCommand{}))
 
 type nvmeDevice struct {
 	Name string
@@ -122,7 +120,7 @@ type nvmeIdentController struct {
 } // 4096 bytes
 
 func (d *nvmeDevice) open() (int, error) {
-	return unix.Open(d.Name, unix.O_RDWR, 0600)
+	return unix.Open(d.Name, unix.O_RDWR, 0o600)
 }
 
 func (d *nvmeDevice) close(fd int) error {
@@ -130,7 +128,6 @@ func (d *nvmeDevice) close(fd int) error {
 }
 
 func (d *nvmeDevice) SerialNumber() (string, error) {
-
 	fd, err := d.open()
 	if err != nil {
 		return "", err

--- a/pkg/sys/smart/scsi.go
+++ b/pkg/sys/smart/scsi.go
@@ -29,16 +29,14 @@ const (
 	// inqReplyLen = 96
 	inqReplyLen = 20
 
-	sgInfoOk     = 0x0 //no sense, host nor driver "noise" or error
-	sgInfoOkMask = 0x1 //indicates whether some error or status field is non-zero
+	sgInfoOk     = 0x0 // no sense, host nor driver "noise" or error
+	sgInfoOkMask = 0x1 // indicates whether some error or status field is non-zero
 
-	sgIO           = 0x2285 //scsi generic ioctl command
+	sgIO           = 0x2285 // scsi generic ioctl command
 	sgDxferFromDev = -3
 )
 
-var (
-	serialInquiry = []byte{0x12, 0x01, 0x80, 0x00, 0x60, 0x00}
-)
+var serialInquiry = []byte{0x12, 0x01, 0x80, 0x00, 0x60, 0x00}
 
 type scsiDevice struct {
 	Name string
@@ -145,7 +143,7 @@ func (d *scsiDevice) sendCDB(cdb []byte, respBuf *[]byte) error {
 }
 
 func (d *scsiDevice) open() (err error) {
-	d.fd, err = unix.Open(d.Name, unix.O_RDWR, 0600)
+	d.fd, err = unix.Open(d.Name, unix.O_RDWR, 0o600)
 	return err
 }
 

--- a/pkg/sys/smart/smart_test.go
+++ b/pkg/sys/smart/smart_test.go
@@ -19,19 +19,22 @@
 package smart
 
 import (
-	"fmt"
+	"os"
 	"testing"
 )
 
-func TestSerialNumber(t1 *testing.T) {
+func TestSerialNumber(t *testing.T) {
 	sn, err := GetSerialNumber("/dev/sdb")
 	if err != nil {
-		t1.Errorf("Cannot get serial number: %v", err)
+		if os.IsPermission(err) {
+			t.Skip()
+		}
+		t.Errorf("Cannot get serial number: %v", err)
 	}
-	fmt.Printf("\nSerial Number of /dev/sdb : %s", sn)
+	t.Logf("Serial Number of /dev/sdb : %s", sn)
 	sn, err = GetSerialNumber("/dev/nvme0n1")
 	if err != nil {
-		t1.Errorf("Cannot get serial number: %v", err)
+		t.Errorf("Cannot get serial number: %v", err)
 	}
-	fmt.Printf("\nSerial Number of /dev/nvme0n1: %s\n\n", sn)
+	t.Logf("Serial Number of /dev/nvme0n1: %s", sn)
 }

--- a/pkg/sys/smart/utils.go
+++ b/pkg/sys/smart/utils.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//intSize is the size in bytes (converted to integer) of 0
+// intSize is the size in bytes (converted to integer) of 0
 const intSize int = int(unsafe.Sizeof(0))
 
 // A ByteOrder specifies how to convert byte sequences

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -17,7 +17,7 @@
 package sys
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/minio/directpv/pkg/mount"
 )
@@ -96,5 +96,5 @@ type Device struct {
 
 // DevPath return /dev notation of the path
 func (d Device) DevPath() string {
-	return filepath.Join("/dev", d.Name)
+	return path.Join("/dev", d.Name)
 }

--- a/pkg/uevent/indexer.go
+++ b/pkg/uevent/indexer.go
@@ -27,9 +27,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var (
-	errNotDirectCSIDriveObject = errors.New("not a directcsidrive object")
-)
+var errNotDirectCSIDriveObject = errors.New("not a directcsidrive object")
 
 type indexer struct {
 	store  cache.Store

--- a/pkg/uevent/listener.go
+++ b/pkg/uevent/listener.go
@@ -322,7 +322,8 @@ func (l *listener) validateDevice(device *sys.Device) (bool, error) {
 func (l *listener) processAdd(ctx context.Context,
 	matchResult matchResult,
 	device *sys.Device,
-	drive *directcsi.DirectCSIDrive) error {
+	drive *directcsi.DirectCSIDrive,
+) error {
 	switch matchResult {
 	case noMatch:
 		return l.handler.Add(ctx, device)
@@ -339,7 +340,8 @@ func (l *listener) processAdd(ctx context.Context,
 func (l *listener) processUpdate(ctx context.Context,
 	matchResult matchResult,
 	device *sys.Device,
-	drive *directcsi.DirectCSIDrive) error {
+	drive *directcsi.DirectCSIDrive,
+) error {
 	switch matchResult {
 	case noMatch:
 		return nil
@@ -375,7 +377,8 @@ func (l *listener) processUpdate(ctx context.Context,
 func (l *listener) processRemove(ctx context.Context,
 	matchResult matchResult,
 	device *sys.Device,
-	drive *directcsi.DirectCSIDrive) error {
+	drive *directcsi.DirectCSIDrive,
+) error {
 	switch matchResult {
 	case noMatch:
 		klog.V(5).InfoS(

--- a/pkg/uevent/sync.go
+++ b/pkg/uevent/sync.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	directcsi "github.com/minio/directpv/pkg/apis/direct.csi.min.io/v1beta4"
@@ -29,9 +29,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var (
-	errDuplicateDevice = errors.New("found duplicate devices for drive")
-)
+var errDuplicateDevice = errors.New("found duplicate devices for drive")
 
 // syncs the directcsidrive states by locally probing the devices
 func (l *listener) sync(ctx context.Context) error {
@@ -204,7 +202,7 @@ func (l *listener) syncDevices(ctx context.Context, devices []*sys.Device) error
 		case 1:
 			klog.V(5).Infof("matched device: %s for drive %s", matchedDevices[0].Name, drive.Name)
 			// unset requested format while matching unidentified drive
-			if drive.Spec.RequestedFormat != nil && matchedDevices[0].FirstMountPoint != filepath.Join(sys.MountRoot, drive.Name) {
+			if drive.Spec.RequestedFormat != nil && matchedDevices[0].FirstMountPoint != path.Join(sys.MountRoot, drive.Name) {
 				drive.Spec.RequestedFormat = nil
 			}
 			if err := l.processMatchedDrive(ctx, matchedDevices[0], drive); err != nil {

--- a/pkg/uevent/utils.go
+++ b/pkg/uevent/utils.go
@@ -17,6 +17,7 @@
 package uevent
 
 import (
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -39,7 +40,7 @@ func getRootBlockPath(devName string) string {
 			sys.DirectCSIPartitionInfix,
 			sys.HostPartitionInfix,
 		)
-		return filepath.Join(sys.HostDevRoot, name)
+		return path.Join(sys.HostDevRoot, name)
 	}
 }
 
@@ -59,7 +60,6 @@ func ValidateMountInfo(device *sys.Device, directCSIDrive *directcsi.DirectCSIDr
 
 // ValidateUDevInfo compares and validates the udevinfo of the device with the DirectCSIDrive
 func ValidateUDevInfo(device *sys.Device, directCSIDrive *directcsi.DirectCSIDrive) bool {
-
 	if directCSIDrive.Status.Path != device.DevPath() {
 		klog.V(3).Infof("[%s] path mismatch: %v -> %v", directCSIDrive.Status.Path, device.DevPath())
 		return false

--- a/pkg/uevent/utils_test.go
+++ b/pkg/uevent/utils_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestGetRootBlockPath(t1 *testing.T) {
-
 	testCases := []struct {
 		name     string
 		devName  string
@@ -107,8 +106,8 @@ func TestGetRootBlockPath(t1 *testing.T) {
 			}
 		})
 	}
-
 }
+
 func TestValidateUDevInfo(t1 *testing.T) {
 	testCases := []struct {
 		device         *sys.Device

--- a/pkg/utils/grpc/server.go
+++ b/pkg/utils/grpc/server.go
@@ -34,8 +34,8 @@ func Run(ctx context.Context,
 	endpoint string,
 	identity csi.IdentityServer,
 	controller csi.ControllerServer,
-	node csi.NodeServer) error {
-
+	node csi.NodeServer,
+) error {
 	parsedURL, err := url.Parse(endpoint)
 	if err != nil {
 		return err
@@ -83,8 +83,8 @@ func Run(ctx context.Context,
 func logGRPC(ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler) (interface{}, error) {
-
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
 	klog.V(5).Infof("GRPC call: %s", info.FullMethod)
 	klog.V(5).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)

--- a/pkg/utils/kubeutils_test.go
+++ b/pkg/utils/kubeutils_test.go
@@ -72,5 +72,4 @@ func TestVolumeStatusTransitions(t1 *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/utils/semver/semver.go
+++ b/pkg/utils/semver/semver.go
@@ -46,15 +46,15 @@ func (v *SemVer) Compare(other *SemVer) int {
 func NewVersion(version string) (*SemVer, error) {
 	versionNumParser := func(end1, end2 rune,
 		followFn1, followFn2 func(rune) (bool, bool, interface{}),
-		shouldContinue bool) func(r rune) (bool, bool, interface{}) {
-
+		shouldContinue bool,
+	) func(r rune) (bool, bool, interface{}) {
 		// This is the definition of parseFunc
 		// input is the current rune being parsed
 		// return values are
 		//  - validSoFar - indicates that the parsing has been successful so far
 		//  - mustHaveMoreInput - indicates that the parsing cannot end at the current rune
 
-		//var parseFn func(in rune) (validSoFar bool, mustHaveMoreInput bool)
+		// var parseFn func(in rune) (validSoFar bool, mustHaveMoreInput bool)
 
 		var parse func(r rune) (bool, bool, interface{})
 		var parseEnd func(r rune) (bool, bool, interface{})
@@ -185,7 +185,6 @@ func NewVersion(version string) (*SemVer, error) {
 				return true, false, parsePrerelease
 			}
 			return false, false, parsePrereleaseStart
-
 		}
 		return parsePrereleaseStart
 	}

--- a/pkg/utils/semver/semver_test.go
+++ b/pkg/utils/semver/semver_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSemVer(t *testing.T) {
 	testSet := map[string]bool{
-		//valid semvers
+		// valid semvers
 		"v0.0.4":                 true,
 		"v1.2.3-1.1+build":       true,
 		"v10.20.30-01xtrtrtr":    true,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -67,7 +68,7 @@ func ToYAML(obj interface{}) (string, error) {
 	return string(data), nil
 }
 
-//WriteObject writes the writer content
+// WriteObject writes the writer content
 func WriteObject(writer io.Writer, obj interface{}) error {
 	y, err := ToYAML(obj)
 	if err != nil {
@@ -119,7 +120,7 @@ func GetDefaultAuditDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(homeDir, defaultDirectCSIDir, auditDir), nil
+	return path.Join(homeDir, defaultDirectCSIDir, auditDir), nil
 }
 
 // OpenAuditFile opens the file for writing
@@ -128,10 +129,10 @@ func OpenAuditFile(auditFile string) (*SafeFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get default audit directory ; %w", err)
 	}
-	if err := os.MkdirAll(defaultAuditDir, 0700); err != nil {
+	if err := os.MkdirAll(defaultAuditDir, 0o700); err != nil {
 		return nil, fmt.Errorf("unable to create default audit directory : %w", err)
 	}
-	return NewSafeFile(filepath.Join(defaultAuditDir, fmt.Sprintf("%v-%v", auditFile, time.Now().UnixNano())))
+	return NewSafeFile(path.Join(defaultAuditDir, fmt.Sprintf("%v-%v", auditFile, time.Now().UnixNano())))
 }
 
 // GetMajorMinorFromStr parses the maj:min string and extracts major and minor

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"reflect"
 	"testing"
 	"time"
@@ -81,8 +81,7 @@ func TestNewSafeFile(t *testing.T) {
 	dirname, _ := os.UserHomeDir()
 	timeinNs := time.Now().UnixNano()
 	homeDir, _ := homedir.Dir()
-	filepath.Join(homeDir, ".direct-csi")
-	defaultDirname := filepath.Join(homeDir, ".direct-csi")
+	defaultDirname := path.Join(homeDir, ".direct-csi")
 	testCases := []struct {
 		input       string
 		output      *SafeFile
@@ -107,7 +106,6 @@ func TestNewSafeFile(t *testing.T) {
 			t.Fatalf("Test %d: expected %v got %v", i+1, test.input, out.filename)
 		}
 	}
-
 }
 
 func TestIsManagedDrive(t *testing.T) {


### PR DESCRIPTION
for platform independent behavior use
path.Join() instead of filepath.Join()

Bonus: move to go1.18.x for all builds
we have been making releases for DirectPV
with go1.18.x for last 3 releases.