### PR TITLE
Probe non-device name mounts

### DIFF
--- a/pkg/node/fake.go
+++ b/pkg/node/fake.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/minio/directpv/pkg/consts"
+	"github.com/minio/directpv/pkg/utils"
 	"github.com/minio/directpv/pkg/xfs"
 )
 
@@ -33,8 +34,8 @@ func createFakeServer() *Server {
 		rack:     "test-rack",
 		zone:     "test-zone",
 		region:   "test-region",
-		getMounts: func() (map[string][]string, map[string][]string, error) {
-			return map[string][]string{consts.MountRootDir: {}}, nil, nil
+		getMounts: func() (map[string]utils.StringSet, error) {
+			return map[string]utils.StringSet{consts.MountRootDir: nil}, nil
 		},
 		getDeviceByFSUUID: func(fsuuid string) (string, error) { return "", nil },
 		bindMount:         func(source, target string, readOnly bool) error { return nil },

--- a/pkg/node/publish_unpublish.go
+++ b/pkg/node/publish_unpublish.go
@@ -118,7 +118,7 @@ func (server *Server) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 	}
 
-	mountPointMap, _, err := server.getMounts()
+	mountPointMap, err := server.getMounts()
 	if err != nil {
 		klog.ErrorS(err, "unable to get mounts")
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/node/server.go
+++ b/pkg/node/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minio/directpv/pkg/metrics"
 	"github.com/minio/directpv/pkg/sys"
 	"github.com/minio/directpv/pkg/types"
+	"github.com/minio/directpv/pkg/utils"
 	"github.com/minio/directpv/pkg/xfs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,7 +42,7 @@ type Server struct {
 	zone     string
 	region   string
 
-	getMounts         func() (map[string][]string, map[string][]string, error)
+	getMounts         func() (map[string]utils.StringSet, error)
 	getDeviceByFSUUID func(fsuuid string) (string, error)
 	bindMount         func(source, target string, readOnly bool) error
 	unmount           func(target string) error
@@ -62,7 +63,10 @@ func NewServer(ctx context.Context,
 		zone:     zone,
 		region:   region,
 
-		getMounts:         sys.GetMounts,
+		getMounts: func() (mountMap map[string]utils.StringSet, err error) {
+			mountMap, _, _, err = sys.GetMounts(false)
+			return
+		},
 		getDeviceByFSUUID: sys.GetDeviceByFSUUID,
 		bindMount:         xfs.BindMount,
 		unmount:           func(target string) error { return sys.Unmount(target, true, true, false) },

--- a/pkg/sys/mount.go
+++ b/pkg/sys/mount.go
@@ -19,6 +19,8 @@ package sys
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/minio/directpv/pkg/utils"
 )
 
 type ErrMountPointAlreadyMounted struct {
@@ -31,8 +33,8 @@ func (e *ErrMountPointAlreadyMounted) Error() string {
 }
 
 // GetMounts returns mount-point to devices and devices to mount-point maps.
-func GetMounts() (mountPointMap, deviceMap map[string][]string, err error) {
-	return getMounts()
+func GetMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap map[string]utils.StringSet, err error) {
+	return getMounts(includeMajorMinorMap)
 }
 
 // Mount mounts device to target using fsType, flags and superBlockFlags.

--- a/pkg/sys/mount_other.go
+++ b/pkg/sys/mount_other.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 )
 
-func getMounts() (mountPointMap, deviceMap map[string][]string, err error) {
+func getMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap map[string]utils.StringSet, err error) {
 	return fmt.Errorf("unsupported operating system %v", runtime.GOOS)
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -103,3 +103,21 @@ func AddDevPrefix(name string) string {
 
 	return "/dev/" + name
 }
+
+type StringSet map[string]struct{}
+
+func (set StringSet) Set(value string) {
+	set[value] = struct{}{}
+}
+
+func (set StringSet) Exist(value string) (found bool) {
+	_, found = set[value]
+	return
+}
+
+func (set StringSet) ToSlice() (values []string) {
+	for value := range set {
+		values = append(values, value)
+	}
+	return
+}


### PR DESCRIPTION
Devices may be mounted using different names e.g. /dev/root. This PR fixes to probe such mounts.

Signed-off-by: Bala.FA <bala@minio.io>