### PR TITLE
Upgrade all the k8s side-car images to the latest compatible versions

### DIFF
--- a/pkg/installer/config.go
+++ b/pkg/installer/config.go
@@ -30,14 +30,14 @@ import (
 
 // CSI provisioner images
 const (
-	// quay.io/minio/csi-provisioner:v2.2.0-go1.18
-	CSIImageCSIProvisioner = "csi-provisioner@sha256:c185db49ba02c384633165894147f8d7041b34b173e82a49d7145e50e809b8d6"
+	// quay.io/minio/csi-provisioner:v3.3.0
+	CSIImageCSIProvisioner = "csi-provisioner:v3.3.0"
 
-	// quay.io/minio/csi-node-driver-registrar:v2.2.0-go1.18
-	CSIImageNodeDriverRegistrar = "csi-node-driver-registrar@sha256:d46524376ffccf2c29f2fb373a67faa0d14a875ae01380fa148b4c5a8d47a6c6"
+	// quay.io/minio/csi-node-driver-registrar:v2.6.0
+	CSIImageNodeDriverRegistrar = "csi-node-driver-registrar:v2.6.0"
 
-	// quay.io/minio/livenessprobe:v2.2.0-go1.18
-	CSIImageLivenessProbe = "livenessprobe@sha256:a3a5f8e046ece910505a7f9529c615547b1152c661f34a64b13ac7d9e13df4a7"
+	// quay.io/minio/livenessprobe:v2.8.0
+	CSIImageLivenessProbe = "livenessprobe:v2.8.0"
 )
 
 func defaultOnEmpty(s, d string) string {

--- a/pkg/installer/v1dot18.go
+++ b/pkg/installer/v1dot18.go
@@ -66,6 +66,8 @@ func (v *v1dot18) installDaemonset(ctx context.Context) error {
 }
 
 func (v *v1dot18) installDeployment(ctx context.Context) error {
+	// the default csi provisioner image doesn't support k8s version < 1.20
+	v.CSIProvisionerImage = "csi-provisioner:v2.2.0-go1.18"
 	return installDeploymentDefault(ctx, v.Config)
 }
 

--- a/pkg/installer/v1dot19.go
+++ b/pkg/installer/v1dot19.go
@@ -66,6 +66,8 @@ func (v *v1dot19) installDaemonset(ctx context.Context) error {
 }
 
 func (v *v1dot19) installDeployment(ctx context.Context) error {
+	// the default csi provisioner image doesn't support k8s version < 1.20
+	v.CSIProvisionerImage = "csi-provisioner:v2.2.0-go1.18"
 	return installDeploymentDefault(ctx, v.Config)
 }
 


### PR DESCRIPTION
This PR upgrades the side car versions to latest. 

(Note: the latest version of csi-provisioner doesn't support k8s versions < 1.20. So, the versions < 1.20 will use the existing v2.2.0 version of the image)

We need to push the following images to `quay.io/minio`

```
k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.0
registry.k8s.io/sig-storage/livenessprobe:v2.8.0
```

So that, the published images look like

```
quay.io/minio/csi-provisioner:v3.3.0
quay.io/minio/csi-node-driver-registrar:v2.6.0
quay.io/minio/livenessprobe:v2.8.0
```