### PR TITLE
fix unidentified drive matching during sync

### DIFF
--- a/.github/workflows/functional-test-1.19.16-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.19.16-ubuntu-18.04.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,9 +50,9 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
+          minikube version: 'v1.28.0'
           kubernetes version: 'v1.19.16'
           github token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/functional-test-1.19.16.yaml
+++ b/.github/workflows/functional-test-1.19.16.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,9 +50,9 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
+          minikube version: 'v1.28.0'
           kubernetes version: 'v1.19.16'
           github token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/functional-test-1.20.15-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.20.15-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.20.14 (Ubuntu 18.04)
+name: Testing on k8s v1.20.15 (Ubuntu 18.04)
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.20.14'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.20.15'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.20.15.yaml
+++ b/.github/workflows/functional-test-1.20.15.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.21.8
+name: Testing on k8s v1.20.15
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.21.8'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.20.15'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.21.14-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.21.14-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.25.1 (Ubuntu 18.04)
+name: Testing on k8s v1.21.14 (Ubuntu 18.04)
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.25.1'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.21.14'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.21.14.yaml
+++ b/.github/workflows/functional-test-1.21.14.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.21.8 (Ubuntu 18.04)
+name: Testing on k8s v1.21.14
 
 on:
   push:
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.21.8'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.21.14'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.22.16-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.22.16-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.24.4
+name: Testing on k8s v1.22.16 (Ubuntu 18.04)
 
 on:
   push:
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.24.4'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.22.16'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.22.16.yaml
+++ b/.github/workflows/functional-test-1.22.16.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.25.1
+name: Testing on k8s v1.22.16
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.25.1'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.22.16'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.23.14-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.23.14-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.23.3 (Ubuntu 18.04)
+name: Testing on k8s v1.23.14 (Ubuntu 18.04)
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.23.3'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.23.14'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.23.14.yaml
+++ b/.github/workflows/functional-test-1.23.14.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.23.3
+name: Testing on k8s v1.23.14
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.23.3'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.23.14'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.24.8-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.24.8-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.24.4 (Ubuntu 18.04)
+name: Testing on k8s v1.24.8 (Ubuntu 18.04)
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.24.4'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.24.8'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.24.8.yaml
+++ b/.github/workflows/functional-test-1.24.8.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.22.5 (Ubuntu 18.04)
+name: Testing on k8s v1.24.8
 
 on:
   push:
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.22.5'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.24.8'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.25.4-ubuntu-18.04.yaml
+++ b/.github/workflows/functional-test-1.25.4-ubuntu-18.04.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.20.14
+name: Testing on k8s v1.25.4 (Ubuntu 18.04)
 
 on:
   push:
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.20.14'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.25.4'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/functional-test-1.25.4.yaml
+++ b/.github/workflows/functional-test-1.25.4.yaml
@@ -1,4 +1,4 @@
-name: Testing on k8s v1.22.5
+name: Testing on k8s v1.25.4
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install dependencies
         run: |
@@ -50,10 +50,10 @@ jobs:
           docker build -t quay.io/minio/directpv:${BUILD_TAG} .
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.0'
-          kubernetes version: 'v1.22.5'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.25.4'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Minikube

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
         
       # https://github.com/docker/setup-qemu-action

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         env:
-          SHELLCHECK_OPTS: -e SC1091
+          SHELLCHECK_OPTS: -e SC1091 -e SC2317
 
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/functests/common.sh
+++ b/functests/common.sh
@@ -111,7 +111,7 @@ function uninstall_directcsi() {
     fi
     while [[ $pending -gt 0 ]]; do
         echo "$ME: waiting for ${pending} direct-csi pods to go down"
-        sleep ${pending}
+        sleep "${pending}"
         pending=$(kubectl get pods --field-selector=status.phase=Running --no-headers --namespace=direct-csi-min-io | wc -l)
     done
 
@@ -220,7 +220,7 @@ function uninstall_minio() {
         fi
         retry_count=$((retry_count + 1))
         echo "$ME: waiting for ${pending} minio pods to go down"
-        sleep ${pending}
+        sleep "${pending}"
         pending=$(kubectl get pods --field-selector=status.phase=Running --no-headers | grep -c '^minio-' || true)
     done
 

--- a/functests/tests.sh
+++ b/functests/tests.sh
@@ -72,7 +72,7 @@ function do_upgrade_test() {
     fi
     while [[ $pending -gt 0 ]]; do
         echo "$ME: waiting for ${pending} direct-csi pods to go down"
-        sleep ${pending}
+        sleep "${pending}"
         pending=$(kubectl get pods --field-selector=status.phase=Running --no-headers --namespace=direct-csi-min-io | wc -l)
     done
 

--- a/install.sh
+++ b/install.sh
@@ -14,11 +14,6 @@ info() {
     echo "[INFO] " "$@"
 }
 
-# warn logs the given argument at warn log level.
-warn() {
-    echo "[WARN] " "$@" >&2
-}
-
 # fatal logs the given argument at fatal log level.
 fatal() {
     echo "[ERROR] " "$@" >&2
@@ -63,7 +58,7 @@ setup_tmp() {
         set +e
         trap - EXIT
         rm -rf "${TMP_DIR}"
-        exit $code
+        exit "$code"
     }
     trap cleanup INT EXIT
 }

--- a/pkg/client/scheme.go
+++ b/pkg/client/scheme.go
@@ -43,14 +43,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientset/fake/register.go
+++ b/pkg/clientset/fake/register.go
@@ -47,14 +47,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientset/scheme/register.go
+++ b/pkg/clientset/scheme/register.go
@@ -47,14 +47,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/controller/validation-handlers.go
+++ b/pkg/controller/validation-handlers.go
@@ -169,11 +169,12 @@ func validateRequestedFormat(directCSIDrive directcsi.DirectCSIDrive, admissionR
 	return validateFS()
 }
 
-/* Validates the following admission rules
-   - Check if the fstype in the requestedFormat == "xfs"
-   - Check if directCSIOwned is not set to True or requestedFormat is set for root partitions (unavailable drives)
-   - Check if requestedFormat is not set for a drive in-use
-   - Check if force option is set if the drive has an existing filesystem or mountpoint
+/*
+Validates the following admission rules
+  - Check if the fstype in the requestedFormat == "xfs"
+  - Check if directCSIOwned is not set to True or requestedFormat is set for root partitions (unavailable drives)
+  - Check if requestedFormat is not set for a drive in-use
+  - Check if force option is set if the drive has an existing filesystem or mountpoint
 */
 func (vh *validationHandler) validateDrive(w http.ResponseWriter, r *http.Request) {
 	admissionReview, err := parseAdmissionReview(r)

--- a/pkg/drive/utils.go
+++ b/pkg/drive/utils.go
@@ -55,18 +55,19 @@ func getFSUUIDFromDrive(drive *directcsi.DirectCSIDrive) string {
 
 // VerifyHostStateForDrive verifies if the drive states match the host info
 // --------------------------------------------------------------------------
-// - error if the v1beta1 drive is not upgraded yet (NOTE: maj:min is not present in v1beta1 API version)
-// - read /run/udev/data/b<maj:min> (refer ReadRunUdevDataByMajorMinor and mapToUdevData funcs)
-//   return err if the file does not exist
-// - construct sys.Device (refer /pkg/uevent/listener.go)
-// - validate the device (refer validateDevice function in pkg uevent)
-// - return an error if validation fails
+//   - error if the v1beta1 drive is not upgraded yet (NOTE: maj:min is not present in v1beta1 API version)
+//   - read /run/udev/data/b<maj:min> (refer ReadRunUdevDataByMajorMinor and mapToUdevData funcs)
+//     return err if the file does not exist
+//   - construct sys.Device (refer /pkg/uevent/listener.go)
+//   - validate the device (refer validateDevice function in pkg uevent)
+//   - return an error if validation fails
 //
 // If validation succeeds,
 // For Ready, InUse drives
-//      - check if the target (/var/lib/direct-csi/mnt/<drive.Name>) is mounted.
-//            If mounted, check the mount options, If not matching, return errInvalidMountOptions
-//            Else, return errNotMounted
+//   - check if the target (/var/lib/direct-csi/mnt/<drive.Name>) is mounted.
+//     If mounted, check the mount options, If not matching, return errInvalidMountOptions
+//     Else, return errNotMounted
+//
 // ----------------------------------------------------------------------------
 func VerifyHostStateForDrive(drive *directcsi.DirectCSIDrive) error {
 	if utils.IsV1Beta1Drive(drive) && drive.Status.MajorNumber == uint32(0) && drive.Status.MinorNumber == uint32(0) {

--- a/pkg/installer/crd_bindata.go
+++ b/pkg/installer/crd_bindata.go
@@ -89,11 +89,13 @@ var _bindata = map[string]func() ([]byte, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/pkg/uevent/sync.go
+++ b/pkg/uevent/sync.go
@@ -132,34 +132,39 @@ func (l *listener) sync(ctx context.Context) error {
 // Non-Managed directcsidrives (Available, Unavailable, Released) :-
 // ==============================================================
 // (*) Tries to match the directcsidrive by the following attributes if available on the directcsidrive
-//     (1)  PartitionNumber
-//     (2)  WWID
-//     (3)  Serial
-//     (4)  SerialLong
-//     (5)  DMUUID
-//     (6)  MDUUID
-//     (7)  ModelNumber
-//     (8)  Vendor
-//     (9)  PartitionUUID
-//     (10) UeventFSUUID
-//     (11) FilesystemUUID (only matcher for v1.4.6 drives)
+//
+//	(1)  PartitionNumber
+//	(2)  WWID
+//	(3)  Serial
+//	(4)  SerialLong
+//	(5)  DMUUID
+//	(6)  MDUUID
+//	(7)  ModelNumber
+//	(8)  Vendor
+//	(9)  PartitionUUID
+//	(10) UeventFSUUID
+//	(11) FilesystemUUID (only matcher for v1.4.6 drives)
+//
 // (*) Matched directcsidrive will be updated.
 // (*) Unmatched directcsidrive will be considered as un-identified directcsidrive. These
-//     directcsidrive could be non-upgraded or empty drives (virtual) with no persistent attributes in them
+//
+//	directcsidrive could be non-upgraded or empty drives (virtual) with no persistent attributes in them
+//
 // (*) Too many device matches will be logged as an error.
 // (*) Unmatched devices will be used for the next directcsidrive match in the iteration.
 //
 // Un-identified directcsidrives (unmatched non-managed directcsidrives) :-
 // =====================================================================
 // (*) Tries to match the directcsidrive by the following attributes on the directcsidrive
-//      (1) drive path
-//      (2) major and minor number
-//      (3) PCIPath (if present)
+//
+//	(1) drive path
+//	(2) major and minor number
+//	(3) PCIPath (if present)
+//
 // (*) Matched directcsidrive will be updated.
 // (*) Unmatched directcsidrive will be deleted
 // (*) Too many device matches will be logged as an error
 // (*) Unmatched devices will be created
-//
 func (l *listener) syncDevices(ctx context.Context, devices []*sys.Device) error {
 	managedDrives, nonManagedDrives, err := l.indexer.listDrives()
 	if err != nil {
@@ -203,7 +208,7 @@ func (l *listener) syncDevices(ctx context.Context, devices []*sys.Device) error
 		case 1:
 			klog.V(5).Infof("matched device: %s for drive %s", matchedDevices[0].Name, drive.Name)
 			// unset requested format while matching unidentified drive
-			if drive.Spec.RequestedFormat != nil && matchedDevices[0].FirstMountPoint != path.Join(sys.MountRoot, drive.Name) {
+			if drive.Spec.RequestedFormat != nil && matchedDevices[0].FSUUID != drive.Name && matchedDevices[0].FirstMountPoint != path.Join(sys.MountRoot, drive.Name) {
 				drive.Spec.RequestedFormat = nil
 			}
 			if err := l.processMatchedDrive(ctx, matchedDevices[0], drive); err != nil {

--- a/pkg/utils/kubeutils.go
+++ b/pkg/utils/kubeutils.go
@@ -113,7 +113,7 @@ func UpdateLabels(object metav1.Object, labels map[LabelKey]LabelValue) {
 // SanitizeKubeResourceName - Sanitize given name to a valid kubernetes name format.
 // RegEx for a kubernetes name is
 //
-//      ([a-z0-9][-a-z0-9]*)?[a-z0-9]
+//	([a-z0-9][-a-z0-9]*)?[a-z0-9]
 //
 // with a max length of 253
 //


### PR DESCRIPTION
The unidentified virtual disks will go to "Unavailable" state if it is attempted to format. This is due to unsetting the requested format during the sync.

The work-around is manually formatting the disks first, to make sure the device has a FS and FSUUID associated and then issue format request using DirectPV