### PR TITLE
Minor fixes to `move` by ignoring `ErrNotExist` errors

### DIFF
--- a/cmd/kubectl-directpv/move.go
+++ b/cmd/kubectl-directpv/move.go
@@ -156,8 +156,8 @@ func moveMain(ctx context.Context, src, dest string) {
 
 	for _, volume := range volumes {
 		if destDrive.AddVolumeFinalizer(volume.Name) {
-			destDrive.Status.FreeCapacity -= requiredCapacity
-			destDrive.Status.AllocatedCapacity += requiredCapacity
+			destDrive.Status.FreeCapacity -= volume.Status.TotalCapacity
+			destDrive.Status.AllocatedCapacity += volume.Status.TotalCapacity
 		}
 	}
 	destDrive.Status.Status = directpvtypes.DriveStatusMoving

--- a/pkg/drive/event.go
+++ b/pkg/drive/event.go
@@ -281,21 +281,21 @@ func (handler *driveEventHandler) move(ctx context.Context, drive *types.Drive) 
 				handler.setQuota,
 				handler.bindMount,
 			)
-			if err != nil {
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				klog.ErrorS(err, "unable to stage volume after volume move",
 					"volume", volume.Name,
 					"dataPath", volume.Status.DataPath,
 					"stagingTargetPath", volume.Status.StagingTargetPath,
 				)
-				return err
 			}
 		} else {
 			volume.Status.Status = directpvtypes.VolumeStatusPending
-			if _, err := client.VolumeClient().Update(ctx, volume, metav1.UpdateOptions{
-				TypeMeta: types.NewVolumeTypeMeta(),
-			}); err != nil {
-				return err
-			}
+		}
+
+		if _, err := client.VolumeClient().Update(ctx, volume, metav1.UpdateOptions{
+			TypeMeta: types.NewVolumeTypeMeta(),
+		}); err != nil {
+			return err
 		}
 
 		client.Eventf(


### PR DESCRIPTION
The following fixes are made in this PR:

- The corresponding directories and mounts for a "Lost" drive will not exist. Such errors can be ignored.
- Fix capacity on the target drive while moving

Steps to test :
- Detach an inuse drive
- Attach a new drive
- Try to move the "Lost" drive to the new drive
- It should succeed instead of failing with 
```
E0215 11:55:35.745639    4478 event.go:285] "unable to stage volume after volume move" err="unable to bind mount volume directory to staging target path; no such file or directory" volume="pvc-5ee1b1c1-32bf-4cde-bc9d-09007e53e172" dataPath="" stagingTargetPath="/var/lib/kubelet/plugins/kubernetes.io/csi/direct-csi-min-io/a3b4ddd629e3723dfe8d6c047a9dc464e26b1609a84b36c5a12a592023f1ef67/globalmount"
```