### PR TITLE
fix creating /var/lib/directpv/mnt directory prior to sync

### DIFF
--- a/cmd/directpv/node-server.go
+++ b/cmd/directpv/node-server.go
@@ -41,6 +41,9 @@ var nodeServerCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(c *cobra.Command, args []string) error {
+		if err := sys.Mkdir(consts.MountRootDir, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
 		if err := device.Sync(c.Context(), nodeID); err != nil {
 			return err
 		}
@@ -93,10 +96,6 @@ func startNodeServer(ctx context.Context) error {
 		metricsPort,
 	)
 	klog.V(3).Infof("Node server started")
-
-	if err = sys.Mkdir(consts.MountRootDir, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
-		return err
-	}
 
 	go func() {
 		if err := runServers(ctx, csiEndpoint, idServer, nil, nodeServer); err != nil {


### PR DESCRIPTION
This fixes the issue seen while upgrading the DirectPV to v4.0.1

```
status:
  allocatedCapacity: 110439672217
  conditions:
  - lastTransitionTime: "2023-03-25T06:58:44Z"
    message: 'unable to mount; mkdir /var/lib/directpv/mnt/8839acb6-6bf6-4361-8424-d27b894c1e00:
      no such file or directory'
    reason: DriveHasMountError
    status: "True"
    type: MountError
```

The device sync happens in the node-server during startup, if the mount dir is not seen, the mount fails. By creating the mount dir before sync, we make sure the mount dir is present during the sync.