### PR TITLE
Make Node{Stage,Publish}Volume RPCs idempotent on kubelet restarts

### DIFF
--- a/pkg/csi/node/fake.go
+++ b/pkg/csi/node/fake.go
@@ -34,8 +34,8 @@ func createFakeServer() *Server {
 		rack:     "test-rack",
 		zone:     "test-zone",
 		region:   "test-region",
-		getMounts: func() (map[string]utils.StringSet, error) {
-			return map[string]utils.StringSet{consts.MountRootDir: nil}, nil
+		getMounts: func() (map[string]utils.StringSet, map[string]utils.StringSet, error) {
+			return map[string]utils.StringSet{consts.MountRootDir: nil}, map[string]utils.StringSet{consts.MountRootDir: nil}, nil
 		},
 		getDeviceByFSUUID: func(fsuuid string) (string, error) { return "", nil },
 		bindMount:         func(source, target string, readOnly bool) error { return nil },

--- a/pkg/csi/node/publish_unpublish_test.go
+++ b/pkg/csi/node/publish_unpublish_test.go
@@ -110,8 +110,8 @@ func TestPublishUnpublishVolume(t *testing.T) {
 	ns := createFakeServer()
 
 	// Publish volume test
-	ns.getMounts = func() (map[string]utils.StringSet, error) {
-		return map[string]utils.StringSet{testStagingPath: nil}, nil
+	ns.getMounts = func() (map[string]utils.StringSet, map[string]utils.StringSet, error) {
+		return map[string]utils.StringSet{testStagingPath: nil}, map[string]utils.StringSet{testStagingPath: nil}, nil
 	}
 	_, err := ns.NodePublishVolume(ctx, &publishVolumeRequest)
 	if err != nil {

--- a/pkg/csi/node/server.go
+++ b/pkg/csi/node/server.go
@@ -42,7 +42,7 @@ type Server struct {
 	zone     string
 	region   string
 
-	getMounts         func() (map[string]utils.StringSet, error)
+	getMounts         func() (mountMap, rootMap map[string]utils.StringSet, err error)
 	getDeviceByFSUUID func(fsuuid string) (string, error)
 	bindMount         func(source, target string, readOnly bool) error
 	unmount           func(target string) error
@@ -59,8 +59,8 @@ func newServer(identity string, nodeID directpvtypes.NodeID, rack, zone, region 
 		zone:     zone,
 		region:   region,
 
-		getMounts: func() (mountMap map[string]utils.StringSet, err error) {
-			mountMap, _, _, err = sys.GetMounts(false)
+		getMounts: func() (mountMap, rootMap map[string]utils.StringSet, err error) {
+			mountMap, _, _, rootMap, err = sys.GetMounts(false)
 			return
 		},
 		getDeviceByFSUUID: sys.GetDeviceByFSUUID,

--- a/pkg/csi/node/stage_unstage.go
+++ b/pkg/csi/node/stage_unstage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/drive"
 	"github.com/minio/directpv/pkg/types"
+	"github.com/minio/directpv/pkg/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,6 +62,10 @@ func (server *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		server.mkdir,
 		server.setQuota,
 		server.bindMount,
+		func() (rootMap map[string]utils.StringSet, err error) {
+			_, rootMap, err = server.getMounts()
+			return
+		},
 	)
 	if err != nil {
 		return nil, status.Error(code, err.Error())

--- a/pkg/csi/node/stage_unstage_test.go
+++ b/pkg/csi/node/stage_unstage_test.go
@@ -76,8 +76,8 @@ func TestNodeStageVolume(t *testing.T) {
 		client.SetVolumeInterface(clientset.DirectpvLatest().DirectPVVolumes())
 
 		nodeServer := createFakeServer()
-		nodeServer.getMounts = func() (map[string]utils.StringSet, error) {
-			return testCase.mountInfo, nil
+		nodeServer.getMounts = func() (map[string]utils.StringSet, map[string]utils.StringSet, error) {
+			return testCase.mountInfo, testCase.mountInfo, nil
 		}
 		nodeServer.bindMount = func(source, stagingTargetPath string, readOnly bool) error {
 			if _, found := testCase.mountInfo[source]; !found {
@@ -147,8 +147,8 @@ func TestStageUnstageVolume(t *testing.T) {
 	ctx := context.TODO()
 	ns := createFakeServer()
 	dataPath := path.Join(consts.MountRootDir, testDriveName, ".FSUUID."+testDriveName, testVolumeName50MB)
-	ns.getMounts = func() (map[string]utils.StringSet, error) {
-		return map[string]utils.StringSet{consts.MountRootDir: nil}, nil
+	ns.getMounts = func() (map[string]utils.StringSet, map[string]utils.StringSet, error) {
+		return map[string]utils.StringSet{consts.MountRootDir: nil}, map[string]utils.StringSet{consts.MountRootDir: nil}, nil
 	}
 
 	// Stage Volume test

--- a/pkg/device/probe_linux.go
+++ b/pkg/device/probe_linux.go
@@ -88,7 +88,7 @@ func probe() (devices []Device, err error) {
 		return nil, err
 	}
 
-	_, deviceMountMap, majorMinorMap, err := sys.GetMounts(true)
+	_, deviceMountMap, majorMinorMap, _, err := sys.GetMounts(true)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func probe() (devices []Device, err error) {
 }
 
 func probeDevices(majorMinor ...string) (devices []Device, err error) {
-	_, deviceMountMap, majorMinorMap, err := sys.GetMounts(true)
+	_, deviceMountMap, majorMinorMap, _, err := sys.GetMounts(true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/initrequest/event.go
+++ b/pkg/initrequest/event.go
@@ -84,7 +84,7 @@ func newInitRequestEventHandler(ctx context.Context, nodeID directpvtypes.NodeID
 		probeDevices: pkgdevice.Probe,
 		getDevices:   pkgdevice.ProbeDevices,
 		getMounts: func() (deviceMap, majorMinorMap map[string]utils.StringSet, err error) {
-			if _, deviceMap, majorMinorMap, err = sys.GetMounts(true); err != nil {
+			if _, deviceMap, majorMinorMap, _, err = sys.GetMounts(true); err != nil {
 				err = fmt.Errorf("unable get mount points; %w", err)
 			}
 			return

--- a/pkg/sys/mount.go
+++ b/pkg/sys/mount.go
@@ -35,7 +35,7 @@ func (e *ErrMountPointAlreadyMounted) Error() string {
 }
 
 // GetMounts returns mount-point to devices and devices to mount-point maps.
-func GetMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap map[string]utils.StringSet, err error) {
+func GetMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap, rootMountPointMap map[string]utils.StringSet, err error) {
 	return getMounts(includeMajorMinorMap)
 }
 

--- a/pkg/sys/mount_other.go
+++ b/pkg/sys/mount_other.go
@@ -25,8 +25,8 @@ import (
 	"github.com/minio/directpv/pkg/utils"
 )
 
-func getMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap map[string]utils.StringSet, err error) {
-	return nil, nil, nil, fmt.Errorf("unsupported operating system %v", runtime.GOOS)
+func getMounts(includeMajorMinorMap bool) (mountPointMap, deviceMap, majorMinorMap, rootMountPointMap map[string]utils.StringSet, err error) {
+	return nil, nil, nil, nil, fmt.Errorf("unsupported operating system %v", runtime.GOOS)
 }
 
 func mount(device, target, fsType string, flags []string, superBlockFlags string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -134,6 +134,21 @@ func (set StringSet) ToSlice() (values []string) {
 	return
 }
 
+// Equal checks whether given StringSet is same or not.
+func (set StringSet) Equal(set2 StringSet) (found bool) {
+	if len(set) != len(set2) {
+		return false
+	}
+
+	for value := range set {
+		if _, found := set2[value]; !found {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Eprintf prints the message to the stdout and stderr based on inputs
 func Eprintf(quiet, asErr bool, format string, a ...any) {
 	if quiet {


### PR DESCRIPTION
When kubelet is restarted NodeStageVolume/NodePublishVolume RPCs are called with existing staging-target-path and target-path. Previously respective RPCs return errors stating staging-target-path/target-path are already mounted.

This PR fixes the issue.