### PR TITLE
Log and continue on XFS probe errors during startup

### DIFF
--- a/pkg/device/sync.go
+++ b/pkg/device/sync.go
@@ -57,7 +57,7 @@ func probeDeviceMap() (map[string][]device, error) {
 		fsuuid, label, totalCapacity, freeCapacity, err := xfs.Probe(utils.AddDevPrefix(dev.Name))
 		if err != nil {
 			if !errors.Is(err, xfs.ErrFSNotFound) {
-				return nil, err
+				klog.ErrorS(err, "unable to probe XFS filesystem", "Device", dev.Name)
 			}
 			continue
 		}


### PR DESCRIPTION
Currently, when any device on the host fails while probing XFS, we error out which may lead to pod crashloops. We can ignore such device probe errors and can log and continue.