### PR TITLE
Adding redhat marketplace annotations

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -9,3 +9,7 @@ operator-sdk generate bundle \
     --output-dir bundles/redhat-marketplace/"$RELEASE" \
     --channels stable \
     --overwrite
+
+# Add needed annotations for redhat marketplace
+yq -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/minio-directpv.clusterserviceversion.yaml
+yq -i '.metadata.annotations."marketplace.openshift.io/support-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/minio-directpv.clusterserviceversion.yaml


### PR DESCRIPTION
### Objective:

To add needed annotations for RedHat MarketPlace Catalog right after we generate the bundle.

### Reason:

* These are needed for Red Hat Marketplace

* Documentation: https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#annotations-validation

* Validation fails when annotations are missing:

```
[annotations-validation : bundle-parse] ++ cat operators/minio-directpv-operator-rhmp/4.0.4/metadata/annotations.yaml
[annotations-validation : bundle-parse] ++ yq -r '.annotations."operators.operatorframework.io.bundle.package.v1"'
[annotations-validation : bundle-parse] + ANNOTATIONS_PACKAGE_NAME=minio-directpv-operator-rhmp
[annotations-validation : bundle-parse] + [[ minio-directpv-operator-rhmp != minio-directpv-operator-rhmp ]]
[annotations-validation : bundle-parse] + [[ redhat-marketplace == \r\e\d\h\a\t\-\m\a\r\k\e\t\p\l\a\c\e ]]
[annotations-validation : bundle-parse] ++ realpath operators/minio-directpv-operator-rhmp/4.0.4
[annotations-validation : bundle-parse] + BUNDLE_PATH=/workspace/source/operators/minio-directpv-operator-rhmp/4.0.4
[annotations-validation : bundle-parse] ++ find /workspace/source/operators/minio-directpv-operator-rhmp/4.0.4 -name '*clusterserviceversion.yaml' -o -name '*clusterserviceversion.yml'
[annotations-validation : bundle-parse] + CSVFILE=/workspace/source/operators/minio-directpv-operator-rhmp/4.0.4/manifests/minio-directpv.clusterserviceversion.yaml
[annotations-validation : bundle-parse] ++ yq -r '.metadata.annotations."marketplace.openshift.io/remote-workflow"'
[annotations-validation : bundle-parse] ++ cat /workspace/source/operators/minio-directpv-operator-rhmp/4.0.4/manifests/minio-directpv.clusterserviceversion.yaml
[annotations-validation : bundle-parse] + MARKETPLACE_REMOTE_WORKFLOW=null
[annotations-validation : bundle-parse] ++ cat /workspace/source/operators/minio-directpv-operator-rhmp/4.0.4/manifests/minio-directpv.clusterserviceversion.yaml
[annotations-validation : bundle-parse] ++ yq -r '.metadata.annotations."marketplace.openshift.io/support-workflow"'
[annotations-validation : bundle-parse] Missing or incorrect 'marketplace.openshift.io/remote-workflow' annotation.
[annotations-validation : bundle-parse] To fix this issue define the annotation in 'manifests/*.clusterserviceversion.yaml' file.
[annotations-validation : bundle-parse] The correct value for the annotation is: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
[annotations-validation : bundle-parse] + MARKETPLACE_SUPPORT_WORKFLOW=null
[annotations-validation : bundle-parse] + EXPECTED_MARKETPLACE_REMOTE_WORKFLOW='https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console'
[annotations-validation : bundle-parse] + EXPECTED_MARKETPLACE_SUPPORT_WORKFLOW='https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console'
[annotations-validation : bundle-parse] + [[ null != https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console ]]
[annotations-validation : bundle-parse] + echo 'Missing or incorrect '\''marketplace.openshift.io/remote-workflow'\'' annotation.'
[annotations-validation : bundle-parse] + echo 'To fix this issue define the annotation in '\''manifests/*.clusterserviceversion.yaml'\'' file.'
[annotations-validation : bundle-parse] + echo 'The correct value for the annotation is: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console'
[annotations-validation : bundle-parse] + exit 1
```