### PR TITLE
fix package name for Red Hat CSI Certification

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,7 +4,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=minio-directpv
+LABEL operators.operatorframework.io.bundle.package.v1=minio-directpv-operator-rhmp
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/bundles/redhat-marketplace/4.0.3/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/bundles/redhat-marketplace/4.0.3/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -4,12 +4,12 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-05-12T20:45:18Z"
+    createdAt: "2023-05-10T22:03:17Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: unknown
     marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
     marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
-  name: minio-directpv.v4.0.4
+  name: minio-directpv-operator-rhmp.v4.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -27,8 +27,8 @@ spec:
     - kind: DirectPVInitRequest
       name: directpvinitrequests.directpv.min.io
       version: v1beta1
-  description: Minio Directpv description. TODO.
-  displayName: Minio Directpv
+  description: Minio Directpv Operator Rhmp description. TODO.
+  displayName: Minio Directpv Operator Rhmp
   icon:
   - base64data: ""
     mediatype: ""
@@ -204,14 +204,14 @@ spec:
           replicas: 3
           selector:
             matchLabels:
-              selector.directpv.min.io: controller-aaz2c
+              selector.directpv.min.io: controller-hfxjk
           strategy: {}
           template:
             metadata:
               annotations:
                 created-by: kubectl-directpv
               labels:
-                selector.directpv.min.io: controller-aaz2c
+                selector.directpv.min.io: controller-hfxjk
               name: controller
               namespace: directpv
             spec:
@@ -271,7 +271,7 @@ spec:
                       fieldPath: spec.nodeName
                 - name: CSI_ENDPOINT
                   value: unix:///csi/csi.sock
-                image: quay.io/minio/directpv:v4.0.4
+                image: quay.io/minio/directpv:v4.0.3
                 name: controller
                 ports:
                 - containerPort: 30443
@@ -327,10 +327,10 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - minio-directpv
+  - minio-directpv-operator-rhmp
   links:
-  - name: Minio Directpv
-    url: https://minio-directpv.domain
+  - name: Minio Directpv Operator Rhmp
+    url: https://minio-directpv-operator-rhmp.domain
   maintainers:
   - email: your@email.com
     name: Maintainer Name
@@ -338,4 +338,4 @@ spec:
   provider:
     name: Provider Name
     url: https://your.domain
-  version: 4.0.4
+  version: 4.0.3

--- a/bundles/redhat-marketplace/4.0.3/metadata/annotations.yaml
+++ b/bundles/redhat-marketplace/4.0.3/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: minio-directpv
+  operators.operatorframework.io.bundle.package.v1: minio-directpv-operator-rhmp
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/bundles/redhat-marketplace/4.0.4/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/bundles/redhat-marketplace/4.0.4/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -4,12 +4,12 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-05-10T22:03:17Z"
+    createdAt: "2023-05-12T20:45:18Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: unknown
     marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
     marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
-  name: minio-directpv.v4.0.3
+  name: minio-directpv-operator-rhmp.v4.0.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -27,8 +27,8 @@ spec:
     - kind: DirectPVInitRequest
       name: directpvinitrequests.directpv.min.io
       version: v1beta1
-  description: Minio Directpv description. TODO.
-  displayName: Minio Directpv
+  description: Minio Directpv Operator Rhmp description. TODO.
+  displayName: Minio Directpv Operator Rhmp
   icon:
   - base64data: ""
     mediatype: ""
@@ -204,14 +204,14 @@ spec:
           replicas: 3
           selector:
             matchLabels:
-              selector.directpv.min.io: controller-hfxjk
+              selector.directpv.min.io: controller-aaz2c
           strategy: {}
           template:
             metadata:
               annotations:
                 created-by: kubectl-directpv
               labels:
-                selector.directpv.min.io: controller-hfxjk
+                selector.directpv.min.io: controller-aaz2c
               name: controller
               namespace: directpv
             spec:
@@ -271,7 +271,7 @@ spec:
                       fieldPath: spec.nodeName
                 - name: CSI_ENDPOINT
                   value: unix:///csi/csi.sock
-                image: quay.io/minio/directpv:v4.0.3
+                image: quay.io/minio/directpv:v4.0.4
                 name: controller
                 ports:
                 - containerPort: 30443
@@ -327,10 +327,10 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - minio-directpv
+  - minio-directpv-operator-rhmp
   links:
-  - name: Minio Directpv
-    url: https://minio-directpv.domain
+  - name: Minio Directpv Operator Rhmp
+    url: https://minio-directpv-operator-rhmp.domain
   maintainers:
   - email: your@email.com
     name: Maintainer Name
@@ -338,4 +338,4 @@ spec:
   provider:
     name: Provider Name
     url: https://your.domain
-  version: 4.0.3
+  version: 4.0.4

--- a/bundles/redhat-marketplace/4.0.4/metadata/annotations.yaml
+++ b/bundles/redhat-marketplace/4.0.4/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: minio-directpv
+  operators.operatorframework.io.bundle.package.v1: minio-directpv-operator-rhmp
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/olm.sh
+++ b/olm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 operator-sdk generate bundle \
-    --package minio-directpv \
+    --package minio-directpv-operator-rhmp \
     --version "$RELEASE" \
     --deploy-dir resources/base/"$RELEASE" \
     --manifests \


### PR DESCRIPTION
### Objective:

To change the package name and pass `annotations-validation` test in the certification process.

### Reason:

The package name should remain consistent throughout the metadata code, particularly in the annotations.yaml file.

### Example:

```
annotations:
  operators.operatorframework.io.bundle.package.v1: minio-operator-rhmp
                                                             |
                                                             |___ Same as folder below

Existing Operator: operators/minio-operator-rhmp/5.0.3/metadata/annotations.yaml
                                      |
                                      |___ Same as package name
```

* Additionally, most of the Operators from all other companies ends with `-rhmp` even ours.

### Documentation:

* https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#annotations-validation
