### PR TITLE
Add supported OC version for Red Hat CSI Certification

### DIFF
--- a/bundles/redhat-marketplace/4.0.3/metadata/annotations.yaml
+++ b/bundles/redhat-marketplace/4.0.3/metadata/annotations.yaml
@@ -8,3 +8,4 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
+  com.redhat.openshift.versions: v4.8-v4.12

--- a/bundles/redhat-marketplace/4.0.4/metadata/annotations.yaml
+++ b/bundles/redhat-marketplace/4.0.4/metadata/annotations.yaml
@@ -8,3 +8,4 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
+  com.redhat.openshift.versions: v4.8-v4.12

--- a/olm.sh
+++ b/olm.sh
@@ -9,3 +9,6 @@ operator-sdk generate bundle \
     --output-dir bundles/redhat-marketplace/"$RELEASE" \
     --channels stable \
     --overwrite
+
+# Annotations to specify OCP versions compatibility.
+yq -i '.annotations."com.redhat.openshift.versions" |= "v4.8-v4.12"' bundles/redhat-marketplace/"$RELEASE"/metadata/annotations.yaml


### PR DESCRIPTION
### Objective:

To set the supported versions of OpenShift for DirectPV.

### Why this is needed?

* Since some old versions of OpenShift has been deprecated, we should specify the range that is supported for OLM tests to pass under these recent versions, from 4.8 onwards. 

### Documentation:

* https://docs.openshift.com/container-platform/4.8/operators/operator_sdk/osdk-working-bundle-images.html