### PR TITLE
fix package name for Red Hat CSI Certification

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+package=minio-directpv-operator-rhmp
+
 operator-sdk generate bundle \
-    --package minio-directpv-operator-rhmp \
+    --package $package \
     --version "$RELEASE" \
     --deploy-dir resources/base/"$RELEASE" \
     --manifests \
@@ -14,5 +16,5 @@ operator-sdk generate bundle \
 yq -i '.annotations."com.redhat.openshift.versions" |= "v4.8-v4.12"' bundles/redhat-marketplace/"$RELEASE"/metadata/annotations.yaml
 
 # Add needed annotations for redhat marketplace
-yq -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/minio-directpv.clusterserviceversion.yaml
-yq -i '.metadata.annotations."marketplace.openshift.io/support-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/minio-directpv.clusterserviceversion.yaml
+yq -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/$package.clusterserviceversion.yaml
+yq -i '.metadata.annotations."marketplace.openshift.io/support-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/$package.clusterserviceversion.yaml


### PR DESCRIPTION
Notice `minio-directpv.clusterserviceversion.yaml` does not longer exist, name has to be corrected accordingly for new package name.