### PR TITLE
Automate the use of SHA Digest for Red Hat CSI Certification

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -18,3 +18,21 @@ yq -i '.annotations."com.redhat.openshift.versions" |= "v4.8-v4.12"' bundles/red
 # Add needed annotations for redhat marketplace
 yq -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/$package.clusterserviceversion.yaml
 yq -i '.metadata.annotations."marketplace.openshift.io/support-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/$package.clusterserviceversion.yaml
+
+# Use SHA Digest for CSI Provisioner Image
+csiProvisionerImage="quay.io/minio/csi-provisioner:v3.4.0"
+csiProvisionerImageDigest=$(podman pull "$csiProvisionerImage" | awk '/Digest/ { print $2}')
+csiProvisionerImageDigest="quay.io/minio/csi-provisioner@${csiProvisionerImageDigest}"
+yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${csiProvisionerImageDigest}\")" bundles/redhat-marketplace/"$RELEASE"/manifests/"$package".clusterserviceversion.yaml
+
+# Use SHA Digest for CSI Resizer Image
+csiResizerImage="quay.io/minio/csi-resizer:v1.7.0"
+csiResizerImageDigest=$(podman pull "$csiResizerImage" | awk '/Digest/ { print $2}')
+csiResizerImageDigest="quay.io/minio/csi-resizer@${csiResizerImageDigest}"
+yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[1].image |= (\"${csiResizerImageDigest}\")" bundles/redhat-marketplace/"$RELEASE"/manifests/"$package".clusterserviceversion.yaml
+
+# Use SHA Digest for DirectPV Image
+directPVImage="quay.io/minio/directpv:v$RELEASE"
+directPVImageDigest=$(podman pull "$directPVImage" | awk '/Digest/ { print $2}')
+directPVImageDigest="quay.io/minio/directpv@${directPVImageDigest}"
+yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[2].image |= (\"${directPVImageDigest}\")" bundles/redhat-marketplace/"$RELEASE"/manifests/"$package".clusterserviceversion.yaml


### PR DESCRIPTION
### Objective:

To automate the introduction of `SHA Digest` so that we don't need to create separate PR to change them.

### Reasoning:

This is needed for RedHat Marketplace certification.

### Testing documentation:

* https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#verify-pinned-digest