### PR TITLE
Using redhat containers in olm script

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -20,15 +20,15 @@ yq -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" |= "http
 yq -i '.metadata.annotations."marketplace.openshift.io/support-workflow" |= "https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console"' bundles/redhat-marketplace/"$RELEASE"/manifests/$package.clusterserviceversion.yaml
 
 # Use SHA Digest for CSI Provisioner Image
-csiProvisionerImage="quay.io/minio/csi-provisioner:v3.4.0"
+csiProvisionerImage="registry.redhat.io/openshift4/ose-csi-external-provisioner:latest"
 csiProvisionerImageDigest=$(podman pull "$csiProvisionerImage" | awk '/Digest/ { print $2}')
-csiProvisionerImageDigest="quay.io/minio/csi-provisioner@${csiProvisionerImageDigest}"
+csiProvisionerImageDigest="registry.redhat.io/openshift4/ose-csi-external-provisioner@${csiProvisionerImageDigest}"
 yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${csiProvisionerImageDigest}\")" bundles/redhat-marketplace/"$RELEASE"/manifests/"$package".clusterserviceversion.yaml
 
 # Use SHA Digest for CSI Resizer Image
-csiResizerImage="quay.io/minio/csi-resizer:v1.7.0"
+csiResizerImage="registry.redhat.io/openshift4/ose-csi-external-resizer-rhel8:latest"
 csiResizerImageDigest=$(podman pull "$csiResizerImage" | awk '/Digest/ { print $2}')
-csiResizerImageDigest="quay.io/minio/csi-resizer@${csiResizerImageDigest}"
+csiResizerImageDigest="registry.redhat.io/openshift4/ose-csi-external-resizer-rhel8@${csiResizerImageDigest}"
 yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[1].image |= (\"${csiResizerImageDigest}\")" bundles/redhat-marketplace/"$RELEASE"/manifests/"$package".clusterserviceversion.yaml
 
 # Use SHA Digest for DirectPV Image


### PR DESCRIPTION
### Objective:

To use RedHat containers in olm script.

### Reason:

Once each container has been properly certified and published, then (and only then) can you certify your operator bundle.

### Case:

https://access.redhat.com/support/cases/#/case/03522469