### PR TITLE
Set XFS max-retry=1 max-timeout=5 for default error conditions

### DIFF
--- a/pkg/xfs/mount_linux.go
+++ b/pkg/xfs/mount_linux.go
@@ -58,6 +58,14 @@ func mount(device, target string) error {
 		klog.ErrorS(err, "unable to set ENOSPC retry_timeout_seconds for device", "name", name)
 	}
 
+	if err := os.WriteFile("/sys/fs/xfs/"+name+"/error/metadata/default/max_retries", []byte("1"), 0o644); err != nil {
+		klog.ErrorS(err, "unable to set default max_retires device", "name", name)
+	}
+
+	if err := os.WriteFile("/sys/fs/xfs/"+name+"/error/metadata/default/retry_timeout_seconds", []byte("5"), 0o644); err != nil {
+		klog.ErrorS(err, "unable to set default retry_timeout_seconds for device", "name", name)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently we set `max-retry=1 max-timeout=5` for EIO and ENOSPC error conditions. We need to set it for default error conditions also.

Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_file_systems/configuring-xfs-error-behavior_managing-file-systems)