### PR TITLE
Adding related images in bundle

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -109,6 +109,20 @@ function main() {
     icon_mediatype=image/png
     "${YQ}" -i ".spec.icon[0].base64data |= (\"${icon_base64data}\")" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
     "${YQ}" -i ".spec.icon[0].mediatype |= (\"${icon_mediatype}\")" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+
+    # To add related images after bundle creation
+    image=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[0].image |= (\"${image}\")" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+    name=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[0].name' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[0].name |= \"${name}\"" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+    image=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[1].image' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[1].image |= (\"${image}\")" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+    name=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[1].name' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[1].name |= \"${name}\"" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+    image=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[2].image' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[2].image |= (\"${image}\")" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
+    name=$("${YQ}" '.spec.install.spec.deployments[0].spec.template.spec.containers[2].name' "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml")
+    "${YQ}" -i ".spec.relatedImages[2].name |= \"${name}\"" "bundles/redhat-marketplace/${BUILD_VERSION}/manifests/${PACKAGE}.clusterserviceversion.yaml"
 }
 
 init "$@"


### PR DESCRIPTION
### Objective:

To add related images to the bundle

### Reasoning:

It is needed for the certification because of: https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#verify-pinned-digest where `spec.relatedImages` section must be present for test to pass.

### Related:

* https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/510

### How it will look:

```yaml
spec:
  relatedImages:
    - image: registry.redhat.io/openshift4/ose-csi-external-provisioner@sha256:778aa6e5ea046bfcd865e665679c30362dc8c00cfb33a0cdcc56b2395e8ab504
      name: csi-provisioner
    - image: registry.redhat.io/openshift4/ose-csi-external-resizer-rhel8@sha256:837b32a0c432123e2605ad6d029e7f3b4489d9c52a9d272c7a133d41ad10db87
      name: csi-resizer
    - image: registry.connect.redhat.com/minio/directpv@sha256:53610c35d42971ad57ce8491dbcab3b95395a68820d9024a1298b9f653802688
      name: controller
```