### PR TITLE
Add a workaround volume suspension for statefulset startup

### DIFF
--- a/docs/volume-management.md
+++ b/docs/volume-management.md
@@ -156,3 +156,15 @@ $ kubectl directpv clean --all
 ```
 
 Refer [clean command](./command-reference.md#clean-command) for more information.
+
+## Suspend volumes
+
+***CAUTION: THIS IS DANGEROUS OPERATION WHICH LEADS TO DATA LOSS***
+
+By Kubernetes design, [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) workload is active only if all of its pods are in running state. Any faulty volumes will prevent the statefulset from starting up. DirectPV provides a workaround to suspend failed volumes by mounting them on empty `/var/lib/directpv/tmp` directory with read-only access. This can be done by adding `directpv.min.io/suspend: "true"` label on the respective volumes. Below is an example:
+
+```sh
+> kubectl directpv label volumes --nodes node-1 --drives dm-3 directpv.min.io/suspend=true
+```
+
+This label can be removed once the failed volumes are fixed. Upon removal, the volumes will resume using the respective allocated drives.

--- a/functests/tests.sh
+++ b/functests/tests.sh
@@ -29,10 +29,12 @@ function run_tests() {
     add_drives "${DIRECTPV_DIR}/kubectl-directpv"
     deploy_minio minio.yaml
     test_force_delete
+    test_volume_supending "${DIRECTPV_DIR}/kubectl-directpv"
     uninstall_minio "${DIRECTPV_DIR}/kubectl-directpv" minio.yaml
     test_volume_expansion "${DIRECTPV_DIR}/kubectl-directpv" sleep.yaml
     remove_drives "${DIRECTPV_DIR}/kubectl-directpv"
     uninstall_directpv "${DIRECTPV_DIR}/kubectl-directpv" "${pod_count}"
+    unmount_directpv
     remove_luks
     remove_lvm
 }

--- a/pkg/apis/directpv.min.io/types/label.go
+++ b/pkg/apis/directpv.min.io/types/label.go
@@ -76,6 +76,9 @@ const (
 
 	// RequestIDLabelKey label key for request ID
 	RequestIDLabelKey LabelKey = consts.GroupName + "/request-id"
+
+	// SuspendLabelKey denotes if the volume is suspended.
+	SuspendLabelKey LabelKey = consts.GroupName + "/suspend"
 )
 
 // LabelValue is a type definition for label value

--- a/pkg/apis/directpv.min.io/v1beta1/volume.go
+++ b/pkg/apis/directpv.min.io/v1beta1/volume.go
@@ -17,6 +17,8 @@
 package v1beta1
 
 import (
+	"strconv"
+
 	"github.com/minio/directpv/pkg/apis/directpv.min.io/types"
 	"github.com/minio/directpv/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,6 +286,11 @@ func (volume DirectPVVolume) GetPodNS() string {
 // GetTenantName returns associated tenant name of this volume.
 func (volume DirectPVVolume) GetTenantName() string {
 	return string(volume.getLabel(types.LabelKey(Group + "/tenant")))
+}
+
+// IsSuspended returns if the volume is suspended.
+func (volume DirectPVVolume) IsSuspended() bool {
+	return string(volume.getLabel(types.SuspendLabelKey)) == strconv.FormatBool(true)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -94,4 +94,7 @@ const (
 
 	LegacyNodeServerName       = "legacy-node-server"
 	LegacyControllerServerName = "legacy-controller"
+
+	// TmpFS mount
+	TmpMountDir = AppRootDir + "/tmp"
 )

--- a/pkg/consts/consts.go.in
+++ b/pkg/consts/consts.go.in
@@ -92,4 +92,7 @@ const (
 
 	LegacyNodeServerName       = "legacy-node-server"
 	LegacyControllerServerName = "legacy-controller"
+
+	// TmpFS mount
+	TmpMountDir = AppRootDir + "/tmp"
 )

--- a/pkg/csi/node/stage_unstage.go
+++ b/pkg/csi/node/stage_unstage.go
@@ -54,6 +54,11 @@ func (server *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
+	if volume.IsSuspended() {
+		// Suspended volumes doesn't require staging.
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
 	code, err := drive.StageVolume(
 		ctx,
 		volume,


### PR DESCRIPTION
As per the k8s limitation, the pod will come up only when all of its volumes are successfully mounted. So, the pod will remain in "ContainerCreating" state forever if the drives has gone faulty or detached from the node.

By suspending such faulty volumes, DirectPV can fake the CSI calls which will allow pods to come up with these mocked volumes and the pod restarts will be resilient.

Mocked volumes will be mounted as "read-only" and will be treated as "offline" volumes.

Fixes #578

Steps to test :-

- Install DirectPV
- Initialize the drives and deploy a workload (functests/minio.yaml)
- Suspend the volumes as shown in troubleshooting.doc
- Restart the MinIO pods
- You should see the container mounts mounted in tmpfs - `/var/lib/directpv/tmp` as read-only. And `mc admin info` should report these volumes as "offline"