### PR TITLE
 fix package name in operator bundle

### DIFF
--- a/helm/bundle/metadata/annotations.yaml
+++ b/helm/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: directpv-operator
+  operators.operatorframework.io.bundle.package.v1: minio-directpv-operator-rhmp
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1


### PR DESCRIPTION
### Objective:

To certify DirectPV Operator.

### Current issue:

* `annotations-validation` failed ❌ in [RedHatMarketPlace PR](https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/542)

### Documentation:

* https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#annotations-validation

```
Also please ensure to double check that your package naming remains consistent throughout the metadata code,
particularly in the annotations.yaml file.
```