### PR TITLE
fix package name in operator bundle generation

### DIFF
--- a/helm/generate.sh
+++ b/helm/generate.sh
@@ -37,7 +37,9 @@ EOF
     BUILD_VERSION="${1/v/}"
     IMAGE_TAG_BASE=quay.io/minio/directpv-operator
     IMG="$IMAGE_TAG_BASE:$BUILD_VERSION"
+    PACKAGE=minio-directpv-operator-rhmp
     BUNDLE_GEN_FLAGS="-q --overwrite --version ${BUILD_VERSION}"
+    BUNDLE_GEN_FLAGS="${BUNDLE_GEN_FLAGS} --package ${PACKAGE}"
     BUNDLE_IMG="${IMAGE_TAG_BASE}-bundle:v${BUILD_VERSION}"
 
 }


### PR DESCRIPTION
### Objective:

To certify DirectPV Operator.

### Current issue:

* `annotations-validation` failed ❌ in [RedHatMarketPlace PR](https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/542)

### Documentation:

* https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#annotations-validation

```
Also please ensure to double check that your package naming remains consistent throughout the metadata code,
particularly in the annotations.yaml file.
```