### PR TITLE
To support multiple architectures as in MinIO Repo

### DIFF
--- a/helm/generate.sh
+++ b/helm/generate.sh
@@ -46,12 +46,12 @@ EOF
 
 function main() {
 
-    # docker-build: Build docker image with the manager.
-    docker buildx build --platform linux/amd64 -t "${IMG}" .
-
     # Ask admin to run this command for you as it requires privileges
-    # docker-push: Push docker image with the manager.
-    # docker push "${IMG}"
+    # docker-build: Build and push docker image with the manager.
+    docker buildx build --push --no-cache \
+    -t "${IMG}" \
+    --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+    -f Dockerfile .
 
     # bundle: Generate bundle manifests and metadata, then validate generated files.
     operator-sdk generate kustomize manifests -q


### PR DESCRIPTION
### Objective:

To push Helm Operator Image to Quay Repo. This time using multiple Architectures as in MinIO Binary: https://github.com/minio/minio/blob/master/docker-buildx.sh#L7 where multiple architectures are observed and same would be expected for this image:

* Link: https://quay.io/repository/minio/minio/manifest/sha256:6fce70c2fd719603cb538e25ec3f58d77c12c1f5141e46240a850065c7ce4470

<img width="1840" alt="Screenshot 2023-09-06 at 7 06 17 AM" src="https://github.com/minio/directpv/assets/6667358/10d4c3d3-0f0d-4d25-9e14-75c7e37ccfaa">

* Link: https://quay.io/repository/operator-framework/helm-operator/manifest/sha256:4c1f130f386aa084efa00755bff07a3d41b76885efdb5f2e2bd33819d2083e8b

<img width="1840" alt="Screenshot 2023-09-06 at 7 13 58 AM" src="https://github.com/minio/directpv/assets/6667358/915185b6-cdea-4efe-9299-b73abb212296">

### For Admin:

* This is how you can push the image:

```sh
cd ~/directpv/helm

docker buildx prune -f

docker buildx build --push --no-cache \
    -t quay.io/minio/directpv-operator:4.0.7 \
    --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
    -f Dockerfile .
```