### PR TITLE
Add IBM annotations to operator bundle

### DIFF
--- a/helm/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/helm/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -65,6 +65,8 @@ metadata:
     capabilities: Basic Install
     createdAt: "2023-08-17T13:36:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
+    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/pricing?utm_source=openshift_console
+    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/support?utm_source=openshift_console
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: minio-directpv-operator-rhmp.v4.0.7
   namespace: placeholder

--- a/helm/config/manifests/bases/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/helm/config/manifests/bases/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -13,6 +13,8 @@ metadata:
       {},"securityContext": {},"service": {"port": 80,"type": "ClusterIP"},"serviceAccount":
       {"annotations": {},"create": true,"name": ""},"tolerations": []}}]'
     capabilities: Basic Install
+    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/pricing?utm_source=openshift_console
+    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/support?utm_source=openshift_console
   name: minio-directpv-operator-rhmp.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
### Objective:

To pass `annotations-validation` test at PR: https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/554

### Reasoning:

* Our MinIO Operator is using these annotations: https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/blob/main/operators/minio-operator-rhmp/5.0.9/manifests/minio-operator-rhmp.clusterserviceversion.yaml#L88 hence passing the validation process

### Additional Information:

* Confirmed with RedHat team on this: https://connect.redhat.com/support/technology-partner/#/case/03614023