### PR TITLE
Correct package name in IBM Annotation to operator bundle

### DIFF
--- a/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -65,8 +65,8 @@ metadata:
     capabilities: Basic Install
     createdAt: "2023-08-17T13:36:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
-    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/pricing?utm_source=openshift_console
-    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/support?utm_source=openshift_console
+    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
+    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: minio-directpv-operator-rhmp.v4.0.7
   namespace: placeholder

--- a/operator/config/manifests/bases/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -13,8 +13,8 @@ metadata:
       {},"securityContext": {},"service": {"port": 80,"type": "ClusterIP"},"serviceAccount":
       {"annotations": {},"create": true,"name": ""},"tolerations": []}}]'
     capabilities: Basic Install
-    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/pricing?utm_source=openshift_console
-    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-operator-rhmp/support?utm_source=openshift_console
+    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
+    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
   name: minio-directpv-operator-rhmp.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
### Objective:

To correct the package in the IBM Annotation, from `minio-operator-rhmp` to `minio-directpv-operator-rhmp`.

### Related:

* https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/555

### Log:

```
[annotations-validation : bundle-parse] + EXPECTED_MARKETPLACE_REMOTE_WORKFLOW='https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console'
[annotations-validation : bundle-parse] Missing or incorrect 'marketplace.openshift.io/remote-workflow' annotation.
[annotations-validation : bundle-parse] To fix this issue define the annotation in 'manifests/*.clusterserviceversion.yaml' file.
[annotations-validation : bundle-parse] + EXPECTED_MARKETPLACE_SUPPORT_WORKFLOW='https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console'
```