### PR TITLE
Adding OpenShift Supported version after generating the bundle

### DIFF
--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -12,3 +12,5 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  # Annotations to specify OCP versions compatibility.
+  com.redhat.openshift.versions: v4.8-v4.13

--- a/release-operator.sh
+++ b/release-operator.sh
@@ -127,6 +127,12 @@ function make_release() {
     (cd config/manager && "${KUSTOMIZE}" edit set image controller="${IMG}")
     # shellcheck disable=SC2086
     "${KUSTOMIZE}" build config/manifests | "${OPERATOR_SDK}" generate bundle ${BUNDLE_GEN_FLAGS}
+    # Since above line overwrites our redhat annotation,
+    # it will be added back:
+    {
+        echo "  # Annotations to specify OCP versions compatibility."
+        echo "  com.redhat.openshift.versions: v4.8-v4.13"
+    } >> operator/bundle/metadata/annotations.yaml
     "${OPERATOR_SDK}" bundle validate ./bundle
     git_commit "Update operator bundle for v${BUILD_VERSION}"
 


### PR DESCRIPTION
### Objective:

To add OpenShift Supported Versions.

### Associated PRs:

* https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/556

### Current Error:

```
[get-supported-versions : supported-version-check] ++ cat config.yaml
[get-supported-versions : supported-version-check] ++ yq -r .organization
[get-supported-versions : supported-version-check] + ORGANIZATION=redhat-marketplace
[get-supported-versions : supported-version-check] + OCP_VERSIONS_OUTPUT_FILE=./ocp_versions.json
[get-supported-versions : supported-version-check] + ocp-version-info --output-file ./ocp_versions.json operators/minio-directpv-operator-rhmp/4.0.7 redhat-marketplace
[get-supported-versions : supported-version-check] Traceback (most recent call last):
[get-supported-versions : supported-version-check]   File "/home/user/.venv/bin/ocp-version-info", line 8, in <module>
[get-supported-versions : supported-version-check]     sys.exit(main())
[get-supported-versions : supported-version-check]              ^^^^^^
[get-supported-versions : supported-version-check]   File "/home/user/.venv/lib/python3.11/site-packages/operatorcert/entrypoints/ocp_version_info.py", line 44, in main
[get-supported-versions : supported-version-check]     version_info = ocp_version_info(bundle_path, args.pyxis_url, args.organization)
[get-supported-versions : supported-version-check]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[get-supported-versions : supported-version-check]   File "/home/user/.venv/lib/python3.11/site-packages/operatorcert/__init__.py", line 176, in ocp_version_info
[get-supported-versions : supported-version-check]     raise ValueError(f"'{OCP_VERSIONS_ANNOTATION}' annotation not defined")
[get-supported-versions : supported-version-check] ValueError: 'com.redhat.openshift.versions' annotation not defined
```

### Solution:

* To add missing annotation but setting overwrite to false so that we keep them.

### Examples:

* In our MinIO Operator we do same:

https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/blob/main/operators/minio-operator-rhmp/5.0.9/metadata/annotations.yaml#L8C1-L9C44