### PR TITLE
Use SHA digests instead of tags in operator bundle

### DIFF
--- a/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -222,7 +222,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -245,7 +245,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=directpv-operator
-                image: quay.io/minio/directpv-operator:4.0.7
+                image: quay.io/minio/directpv-operator@sha256:dadf28674b15c256bc5dec3e99d90f811ea3ac1fdee17c51e2928063a5341e5e
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: quay.io/cniackz4/directpv-operator
-  newTag: 4.0.7
+- digest: sha256:dadf28674b15c256bc5dec3e99d90f811ea3ac1fdee17c51e2928063a5341e5e
+  name: controller
+  newName: quay.io/minio/directpv-operator


### PR DESCRIPTION
### Objective:

To use SHA digests instead of tags

### Reasoning:

* [verify-pinned-digest](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#verify-pinned-digest)

* It is a requirement from RedHat to use SHA Digests.