### PR TITLE
Adding related images field

### DIFF
--- a/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/minio-directpv-operator-rhmp.clusterserviceversion.yaml
@@ -332,3 +332,8 @@ spec:
     name: DirectPV
     url: https://min.io/directpv
   version: 4.0.7
+  relatedImages:
+    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
+      name: kube-rbac-proxy
+    - image: quay.io/minio/directpv-operator@sha256:dadf28674b15c256bc5dec3e99d90f811ea3ac1fdee17c51e2928063a5341e5e
+      name: manager


### PR DESCRIPTION
### Objective:

To add related images field as is needed for the red hat certification.

### Additional information:

We need a post script to get the digest form once images has been pushed.

### Documentation:

* [verify-pinned-digest](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#verify-pinned-digest)

* This step also checks for the existence of a `spec.relatedImages` section in your Cluster Service Version (CSV).

