### PR TITLE
Adding the project for certified operators

### DIFF
--- a/operator/bundle/ci.yaml
+++ b/operator/bundle/ci.yaml
@@ -1,0 +1,1 @@
+cert_project_id: 65130298e32d35ffc65f5094


### PR DESCRIPTION
### Objective:

To add certified operators project in our DirectPV Repository rather than me adding it manually.

### Reasoning:

* Previously I was adding this ID manually.
* Now, I want this to be added and stored in our repository

### Project:

* [DirectPV Helm Operator for Certified Operators run by RedHat](https://connect.redhat.com/projects/65130298e32d35ffc65f5094/overview)