### PR TITLE
Helm Operator: Removing IBM Annotations

### DIFF
--- a/operator/bundle/manifests/minio-directpv-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/minio-directpv-operator.clusterserviceversion.yaml
@@ -5,8 +5,6 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     createdAt: "2023-09-26T14:31:36Z"
-    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
-    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: minio-directpv-operator.v4.0.8

--- a/operator/config/manifests/bases/minio-directpv-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/minio-directpv-operator.clusterserviceversion.yaml
@@ -13,8 +13,6 @@ metadata:
       {},"securityContext": {},"service": {"port": 80,"type": "ClusterIP"},"serviceAccount":
       {"annotations": {},"create": true,"name": ""},"tolerations": []}}]'
     capabilities: Basic Install
-    marketplace.openshift.io/remote-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/pricing?utm_source=openshift_console
-    marketplace.openshift.io/support-workflow: https://marketplace.redhat.com/en-us/operators/minio-directpv-operator-rhmp/support?utm_source=openshift_console
   name: minio-directpv-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
### Objective:

To remove IBM Annotations.

### Reason:

We chose to utilize certified operators managed by RedHat instead of the IBM marketplace for the sake of simplicity.

* [certified-operators](https://github.com/redhat-openshift-ecosystem/certified-operators): Managed by RedHat
* [redhat-marketplace-operators](https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators): Managed by IBM

### Related PR:

* [operator minio-directpv-operator (4.0.8)](https://github.com/redhat-openshift-ecosystem/certified-operators/pull/2900)