### PR TITLE
Correcting the Operator example

### DIFF
--- a/operator/examples/my-directpv.yaml
+++ b/operator/examples/my-directpv.yaml
@@ -1,5 +1,5 @@
 apiVersion: charts.quay.io/v1alpha1
-kind: DirectpvChart
+kind: DirectPVChart
 metadata:
   name: directpvchart-sample
 spec:
@@ -21,5 +21,3 @@ spec:
     create: true
     name: ""
   tolerations: []
-  
-  


### PR DESCRIPTION
### Objective:

To correct our Operator's example.

### Issue:

```sh
$ oc apply -f my-directpv.yaml 
error: resource mapping not found for name: "directpvchart-sample" namespace: "" from "my-directpv.yaml": no matches for kind "DirectpvChart" in version "charts.quay.io/v1alpha1"
ensure CRDs are installed first
```

### Solution:

Change from `DirectpvChart` to `DirectPVChart`

### Testing:

```sh
$ oc apply -f my-directpv.yaml 
directpvchart.charts.quay.io/directpvchart-sample created
```

