### PR TITLE
Correcting Chart Kind in missing spots

### DIFF
--- a/operator/config/samples/charts_v1alpha1_directpvchart.yaml
+++ b/operator/config/samples/charts_v1alpha1_directpvchart.yaml
@@ -1,5 +1,5 @@
 apiVersion: charts.quay.io/v1alpha1
-kind: DirectpvChart
+kind: DirectPVChart
 metadata:
   name: directpvchart-sample
 spec:

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -1,6 +1,6 @@
 # Use the 'create api' subcommand to add watches to this file.
 - group: charts.quay.io
   version: v1alpha1
-  kind: DirectpvChart
+  kind: DirectPVChart
   chart: helm-charts/directpv-chart
 #+kubebuilder:scaffold:watch


### PR DESCRIPTION
### Objective:

To be able to install DirectPV with Operator in OpenShift cluster.

### Story:

While validating latest changes, I found another issue:

```
{
	"level":"error",
	"ts":"2023-10-03T23:27:45Z",
	"logger":"controller-runtime.source",
	"msg":"if kind is a CRD, it should be installed before calling Start",
	"kind":"DirectpvChart.charts.quay.io",
	"error":"no matches for kind \"DirectpvChart\" in version \"charts.quay.io/v1alpha1\"",
	"stacktrace":"sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/source/source.go:143\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:235\nk8s.io/apimachinery/pkg/util/wait.WaitForWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:662\nk8s.io/apimachinery/pkg/util/wait.poll\n\t/go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:596\nk8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:547\nsigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/source/source.go:136"
}
```

### Solution:

I was able to correct this last problem with changes in two more spots:

```
Cesars-MacBook-Pro:operator cniackz$ git diff watches.yaml
diff --git a/operator/watches.yaml b/operator/watches.yaml
index 01013f8..0088bbe 100644
--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -1,6 +1,6 @@
 # Use the 'create api' subcommand to add watches to this file.
 - group: charts.quay.io
   version: v1alpha1
-  kind: DirectpvChart
+  kind: DirectPVChart
   chart: helm-charts/directpv-chart
 #+kubebuilder:scaffold:watch
```
```
Cesars-MacBook-Pro:operator cniackz$ git diff config/samples/charts_v1alpha1_directpvchart.yaml
diff --git a/operator/config/samples/charts_v1alpha1_directpvchart.yaml b/operator/config/samples/charts_v1alpha1_directpvchart.yaml
index fce275d..682f4f9 100644
--- a/operator/config/samples/charts_v1alpha1_directpvchart.yaml
+++ b/operator/config/samples/charts_v1alpha1_directpvchart.yaml
@@ -1,5 +1,5 @@
 apiVersion: charts.quay.io/v1alpha1
-kind: DirectpvChart
+kind: DirectPVChart
 metadata:
   name: directpvchart-sample
 spec:

```

And finally I am able to get DirectPV installed and working in OpenShift with Helm Operator. I will document the whole process which is very large in one wiki and share, meantime help me to review this change.