### PR TITLE
fix regression assigning AuditWriter in installer args

### DIFF
--- a/cmd/kubectl-directpv/install.go
+++ b/cmd/kubectl-directpv/install.go
@@ -185,9 +185,10 @@ func installMain(ctx context.Context) {
 		OutputFormat:     outputFormat,
 		Declarative:      declarativeFlag,
 		Openshift:        openshiftFlag,
-		AuditWriter:      file,
 	}
-
+	if file != nil {
+		args.AuditWriter = file
+	}
 	var failed bool
 	var wg sync.WaitGroup
 	var installedComponents []installer.Component


### PR DESCRIPTION
```
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x92de73]

goroutine 1 [running]:
github.com/minio/directpv/pkg/utils.(*SafeFile).Write(0x1b78fa0?, {0xc000784600?, 0x0?, 0x0?})
github.com/minio/directpv/pkg/utils/utils.go:85 +0x13
github.com/minio/directpv/pkg/admin/installer.(*Args).writeObject(0xc000040280, {0x1e504c0?, 0xc00049a9a0?})
github.com/minio/directpv/pkg/admin/installer/args.go:140 +0xd4
github.com/minio/directpv/pkg/admin/installer.namespaceTask.createNamespace({0x1e64570?}, {0x1e64570, 0xc0003acbe0}, 0xc000040280)
github.com/minio/directpv/pkg/admin/installer/namespace.go:110 +0x465
github.com/minio/directpv/pkg/admin/installer.namespaceTask.Execute({0x3?}, {0x1e64570?, 0xc0003acbe0?}, 0xc000487540?)
github.com/minio/directpv/pkg/admin/installer/namespace.go:46 +0x1d
github.com/minio/directpv/pkg/admin/installer.Install({0x1e64570, 0xc0003acbe0}, 0xc000040280, {0xc0004879e8, 0x8, 0x1e6d1a0?})
github.com/minio/directpv/pkg/admin/installer/installer.go:83 +0x514
github.com/minio/directpv/pkg/admin.(*Client).Install(0xc000496028, {_, _}, {{0xc0001d8b60, 0xf}, {0x1bb0f18, 0x7}, {0x1baf943, 0x5}, {0x2cd7a00, ...}, ...}, ...)
github.com/minio/directpv/pkg/admin/install.go:146 +0x7e7
main.installMain({0x1e64570, 0xc0003acbe0})
github.com/minio/directpv/cmd/kubectl-directpv/install.go:286 +0xaf8
main.init.func9(0x2c5b580?, {0xc0003d2e20?, 0x0?, 0x1?})
github.com/minio/directpv/cmd/kubectl-directpv/install.go:100 +0x25
github.com/spf13/cobra.(*Command).execute(0x2c5b580, {0xc0003d2e00, 0x1, 0x1})
github.com/spf13/cobra@v1.8.1/command.go:989 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x2c5c3e0)
github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
github.com/spf13/cobra@v1.8.1/command.go:1034
main.main()
github.com/minio/directpv/cmd/kubectl-directpv/main.go:193 +0x14e
```