### PR TITLE
Fix size probe for invalid devices

### DIFF
--- a/pkg/device/sysfs_linux.go
+++ b/pkg/device/sysfs_linux.go
@@ -73,7 +73,7 @@ func getReadOnly(name string) (bool, error) {
 
 func getSize(name string) (uint64, error) {
 	s, err := readFirstLine("/sys/class/block/" + name + "/size")
-	if err != nil {
+	if err != nil || s == "" {
 		return 0, err
 	}
 	ui64, err := strconv.ParseUint(s, 10, 64)


### PR DESCRIPTION
for any invalid (or) detached drives, size probe will fail with the following error

```
strconv.ParseUint: parsing "": invalid syntax
```

which prevents the directpv containers to start

bonus: improve probe error messages