### PR TITLE
install: initialize admin and legacy client to avoid crash for dry-run mode

### DIFF
--- a/cmd/kubectl-directpv/install.go
+++ b/cmd/kubectl-directpv/install.go
@@ -31,7 +31,6 @@ import (
 	"github.com/minio/directpv/pkg/admin/installer"
 	"github.com/minio/directpv/pkg/consts"
 	"github.com/minio/directpv/pkg/k8s"
-	legacyclient "github.com/minio/directpv/pkg/legacy/client"
 	"github.com/minio/directpv/pkg/utils"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -192,11 +191,6 @@ func installMain(ctx context.Context) {
 	var failed bool
 	var wg sync.WaitGroup
 	var installedComponents []installer.Component
-	legacyClient, err := legacyclient.NewClient(adminClient.K8s())
-	if err != nil {
-		fmt.Println("error creating legacy client:", err)
-		return
-	}
 	installerTasks := installer.GetDefaultTasks(adminClient.Client, legacyClient)
 	enableProgress := !dryRun && !declarativeFlag && !quietFlag
 	if enableProgress {

--- a/cmd/kubectl-directpv/main.go
+++ b/cmd/kubectl-directpv/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minio/directpv/pkg/admin"
 	"github.com/minio/directpv/pkg/consts"
 	"github.com/minio/directpv/pkg/k8s"
+	legacy "github.com/minio/directpv/pkg/legacy/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
@@ -37,8 +38,9 @@ import (
 var Version string
 
 var (
-	disableInit bool
-	adminClient *admin.Client
+	disableInit  bool
+	adminClient  *admin.Client
+	legacyClient *legacy.Client
 )
 
 var mainCmd = &cobra.Command{
@@ -61,6 +63,13 @@ var mainCmd = &cobra.Command{
 			if err != nil {
 				klog.Fatalf("unable to create admin client; %v", err)
 			}
+			legacyClient, err = legacy.NewClient(adminClient.K8s())
+			if err != nil {
+				klog.Fatalf("unable to create legacy client; %v", err)
+			}
+		} else {
+			adminClient = &admin.Client{}
+			legacyClient = &legacy.Client{}
 		}
 		return nil
 	},


### PR DESCRIPTION
```
main.installMain({0x1dbf3e0, 0xc000486c30})
	github.com/minio/directpv/cmd/kubectl-directpv/install.go:194 +0x5bd
main.init.func9(0x2b62700?, {0xc000402360?, 0x0?, 0x9?})
	github.com/minio/directpv/cmd/kubectl-directpv/install.go:100 +0x25
github.com/spf13/cobra.(*Command).execute(0x2b62700, {0xc0004022d0, 0x9, 0x9})
	github.com/spf13/cobra@v1.8.1/command.go:989 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x2b63560)
	github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.1/command.go:1034
main.main()
	github.com/minio/directpv/cmd/kubectl-directpv/main.go:193 +0x14e
```