### PR TITLE
fix: do not allow removing/changing the reserved labels

### DIFF
--- a/cmd/kubectl-directpv/list.go
+++ b/cmd/kubectl-directpv/list.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/minio/directpv/pkg/apis/directpv.min.io/types"
 	"github.com/minio/directpv/pkg/consts"
 	"github.com/spf13/cobra"
 )
@@ -64,8 +65,13 @@ func validateListCmd() error {
 func labelsToString(labels map[string]string) string {
 	var labelsArray []string
 	for k, v := range labels {
-		k = strings.TrimPrefix(k, consts.GroupName+"/")
-		labelsArray = append(labelsArray, fmt.Sprintf("%s=%v", k, v))
+		if !types.LabelKey(k).IsReserved() {
+			k = strings.TrimPrefix(k, consts.GroupName+"/")
+			labelsArray = append(labelsArray, fmt.Sprintf("%s=%v", k, v))
+		}
+	}
+	if len(labelsArray) == 0 {
+		return "-"
 	}
 	sort.Strings(labelsArray)
 	return strings.Join(labelsArray, ",")

--- a/pkg/admin/label_drives.go
+++ b/pkg/admin/label_drives.go
@@ -62,6 +62,17 @@ func (client *Client) LabelDrives(ctx context.Context, args LabelDriveArgs, labe
 		log = nullLogger
 	}
 
+	for _, label := range labels {
+		if label.Key.IsReserved() {
+			action := "use"
+			if label.Remove {
+				action = "remove"
+			}
+			err = fmt.Errorf("cannot %v reserved key %v", action, label.Key)
+			return
+		}
+	}
+
 	var processed bool
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()

--- a/pkg/admin/label_volumes.go
+++ b/pkg/admin/label_volumes.go
@@ -51,6 +51,17 @@ func (client *Client) LabelVolumes(ctx context.Context, args LabelVolumeArgs, la
 		log = nullLogger
 	}
 
+	for _, label := range labels {
+		if label.Key.IsReserved() {
+			action := "use"
+			if label.Remove {
+				action = "remove"
+			}
+			err = fmt.Errorf("cannot %v reserved key %v", action, label.Key)
+			return
+		}
+	}
+
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 

--- a/pkg/apis/directpv.min.io/types/label.go
+++ b/pkg/apis/directpv.min.io/types/label.go
@@ -96,6 +96,35 @@ const (
 	PluginVersionLabelKey LabelKey = consts.GroupName + "/plugin-version"
 )
 
+var reservedLabelKeys = map[LabelKey]struct{}{
+	NodeLabelKey:           {},
+	DriveNameLabelKey:      {},
+	AccessTierLabelKey:     {},
+	DriveLabelKey:          {},
+	VersionLabelKey:        {},
+	CreatedByLabelKey:      {},
+	PodNameLabelKey:        {},
+	PodNSLabelKey:          {},
+	LatestVersionLabelKey:  {},
+	TopologyDriverIdentity: {},
+	TopologyDriverRack:     {},
+	TopologyDriverZone:     {},
+	TopologyDriverRegion:   {},
+	MigratedLabelKey:       {},
+	RequestIDLabelKey:      {},
+	SuspendLabelKey:        {},
+	VolumeClaimIDLabelKey:  {},
+	ClaimIDLabelKey:        {},
+	ImageTagLabelKey:       {},
+	PluginVersionLabelKey:  {},
+}
+
+// IsReserved returns if the key is a reserved key
+func (k LabelKey) IsReserved() bool {
+	_, found := reservedLabelKeys[k]
+	return found || strings.HasPrefix(string(k), VolumeClaimIDLabelKeyPrefix)
+}
+
 // LabelValue is a type definition for label value
 type LabelValue string
 


### PR DESCRIPTION
also, show only custom labels in `kubectl directpv list drives --show-labels` and `kubectl directpv list volumes --show-labels`