### PR TITLE
Add `target_commitish` to goreleaser spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build
 
 on:
   push:
-    branches: [ master, v4.0 ]
+    branches: [master, v4.0]
 
   pull_request:
-    branches: [ master, v4.0 ]
+    branches: [master, v4.0]
 
 # This ensures that previous jobs for the PR are canceled when the PR is
 # updated.
@@ -35,7 +35,6 @@ jobs:
           go test -v ./...
       - uses: docker/setup-qemu-action@v3
       - name: Check Goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --skip-publish --skip-sign --clean --snapshot
+          args: release --skip=publish,sign --clean --snapshot

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,15 +1,19 @@
+---
+version: 2
 project_name: directpv
 
 release:
-   name_template: "Release version {{.Version}}"
+  name_template: "Release version {{.Version}}"
 
-   github:
+  target_commitish: "{{ .Commit }}"
+
+  github:
     owner: minio
     name: directpv
 
-   extra_files:
-     - glob: "*.minisig"
-     - glob: "*.zip"
+  extra_files:
+    - glob: "*.minisig"
+    - glob: "*.zip"
 
 before:
   hooks:
@@ -17,8 +21,7 @@ before:
     - go mod download
 
 builds:
-  -
-    main: ./cmd/directpv
+  - main: ./cmd/directpv
     id: directpv
     binary: directpv
     goos:
@@ -35,8 +38,7 @@ builds:
     ldflags:
       - -s -w -X main.Version={{ .Tag }}
 
-  -
-    main: ./cmd/kubectl-directpv
+  - main: ./cmd/kubectl-directpv
     id: kubectl-directpv
     binary: kubectl-directpv
     goos:
@@ -61,61 +63,60 @@ builds:
       post: ./package.sh {{ .Path }}
 
 archives:
-  -
-    allow_different_binary_count: true
+  - allow_different_binary_count: true
     format: binary
 
 changelog:
   sort: asc
 
 dockers:
-- image_templates:
-  - "quay.io/minio/directpv:{{ .Tag }}-amd64"
-  use: buildx
-  goarch: amd64
-  ids:
-    - directpv
-  dockerfile: Dockerfile
-  extra_files:
-    - LICENSE
-    - CREDITS
-    - AlmaLinux.repo
-  build_flag_templates:
-  - "--platform=linux/amd64"
-- image_templates:
-  - "quay.io/minio/directpv:{{ .Tag }}-ppc64le"
-  use: buildx
-  goarch: ppc64le
-  ids:
-    - directpv
-  dockerfile: Dockerfile
-  extra_files:
-    - LICENSE
-    - CREDITS
-    - AlmaLinux.repo
-  build_flag_templates:
-  - "--platform=linux/ppc64le"
-- image_templates:
-  - "quay.io/minio/directpv:{{ .Tag }}-arm64"
-  use: buildx
-  goarch: arm64
-  ids:
-    - directpv
-  dockerfile: Dockerfile
-  extra_files:
-    - LICENSE
-    - CREDITS
-    - AlmaLinux.repo
-  build_flag_templates:
-  - "--platform=linux/arm64"
+  - image_templates:
+      - "quay.io/minio/directpv:{{ .Tag }}-amd64"
+    use: buildx
+    goarch: amd64
+    ids:
+      - directpv
+    dockerfile: Dockerfile
+    extra_files:
+      - LICENSE
+      - CREDITS
+      - AlmaLinux.repo
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "quay.io/minio/directpv:{{ .Tag }}-ppc64le"
+    use: buildx
+    goarch: ppc64le
+    ids:
+      - directpv
+    dockerfile: Dockerfile
+    extra_files:
+      - LICENSE
+      - CREDITS
+      - AlmaLinux.repo
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+  - image_templates:
+      - "quay.io/minio/directpv:{{ .Tag }}-arm64"
+    use: buildx
+    goarch: arm64
+    ids:
+      - directpv
+    dockerfile: Dockerfile
+    extra_files:
+      - LICENSE
+      - CREDITS
+      - AlmaLinux.repo
+    build_flag_templates:
+      - "--platform=linux/arm64"
 docker_manifests:
-- name_template: quay.io/minio/directpv:{{ .Tag }}
-  image_templates:
-  - quay.io/minio/directpv:{{ .Tag }}-amd64
-  - quay.io/minio/directpv:{{ .Tag }}-arm64
-  - quay.io/minio/directpv:{{ .Tag }}-ppc64le
-- name_template: quay.io/minio/directpv:latest
-  image_templates:
-  - quay.io/minio/directpv:{{ .Tag }}-amd64
-  - quay.io/minio/directpv:{{ .Tag }}-arm64
-  - quay.io/minio/directpv:{{ .Tag }}-ppc64le
+  - name_template: quay.io/minio/directpv:{{ .Tag }}
+    image_templates:
+      - quay.io/minio/directpv:{{ .Tag }}-amd64
+      - quay.io/minio/directpv:{{ .Tag }}-arm64
+      - quay.io/minio/directpv:{{ .Tag }}-ppc64le
+  - name_template: quay.io/minio/directpv:latest
+    image_templates:
+      - quay.io/minio/directpv:{{ .Tag }}-amd64
+      - quay.io/minio/directpv:{{ .Tag }}-arm64
+      - quay.io/minio/directpv:{{ .Tag }}-ppc64le


### PR DESCRIPTION
This prevents an issue during release that causes github to create a tag on master instead of on the branch from which the release was created by goreleaser.