### PR TITLE
Add image-tag annotation to the deployment and daemonset

### DIFF
--- a/pkg/admin/installer/args.go
+++ b/pkg/admin/installer/args.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"regexp"
 
 	"github.com/minio/directpv/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -79,10 +80,18 @@ type Args struct {
 	nodeDriverRegistrarImage string
 	livenessProbeImage       string
 	csiResizerImage          string
+	imageTag                 string
 }
+
+var imageTagRegex = regexp.MustCompile(`:([^/]+)$`)
 
 // NewArgs creates arguments for DirectPV installation.
 func NewArgs(image string) *Args {
+	imageTag := "dev"
+	matchIndex := imageTagRegex.FindStringSubmatchIndex(image)
+	if len(matchIndex) > 0 && len(image) > matchIndex[0]+1 {
+		imageTag = image[matchIndex[0]+1:]
+	}
 	return &Args{
 		image:    image,
 		Registry: "quay.io",
@@ -92,6 +101,7 @@ func NewArgs(image string) *Args {
 		nodeDriverRegistrarImage: nodeDriverRegistrarImage,
 		livenessProbeImage:       livenessProbeImage,
 		csiResizerImage:          csiResizerImage,
+		imageTag:                 imageTag,
 	}
 }
 

--- a/pkg/admin/installer/daemonset.go
+++ b/pkg/admin/installer/daemonset.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	directpvtypes "github.com/minio/directpv/pkg/apis/directpv.min.io/types"
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/consts"
 	"github.com/minio/directpv/pkg/k8s"
@@ -214,7 +215,10 @@ func newDaemonset(podSpec corev1.PodSpec, name, selectorValue string, args *Args
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    defaultLabels,
+			Annotations: map[string]string{
+				string(directpvtypes.ImageTagLabelKey): args.imageTag,
+			},
+			Labels: defaultLabels,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, selectorKey, selectorValue),

--- a/pkg/admin/installer/deployment.go
+++ b/pkg/admin/installer/deployment.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	directpvtypes "github.com/minio/directpv/pkg/apis/directpv.min.io/types"
 	"github.com/minio/directpv/pkg/client"
 	"github.com/minio/directpv/pkg/consts"
 	"github.com/minio/directpv/pkg/k8s"
@@ -206,7 +207,10 @@ func (t deploymentTask) doCreateDeployment(ctx context.Context, args *Args, lega
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    defaultLabels,
+			Annotations: map[string]string{
+				string(directpvtypes.ImageTagLabelKey): args.imageTag,
+			},
+			Labels: defaultLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,

--- a/pkg/apis/directpv.min.io/types/label.go
+++ b/pkg/apis/directpv.min.io/types/label.go
@@ -88,6 +88,9 @@ const (
 
 	// ClaimIDLabelKey label key to denote the claim id of the volumes
 	ClaimIDLabelKey LabelKey = consts.GroupName + "/claim-id"
+
+	// ImageTagLabelKey denotes the tag of the directpv container image
+	ImageTagLabelKey LabelKey = consts.GroupName + "/image-tag"
 )
 
 var reservedLabelKeys = map[LabelKey]struct{}{
@@ -109,6 +112,7 @@ var reservedLabelKeys = map[LabelKey]struct{}{
 	SuspendLabelKey:        {},
 	VolumeClaimIDLabelKey:  {},
 	ClaimIDLabelKey:        {},
+	ImageTagLabelKey:       {},
 }
 
 // IsReserved returns if the key is a reserved key

--- a/resources/base/DaemonSet.yaml
+++ b/resources/base/DaemonSet.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null
+  annotations:
+    directpv.min.io/image-tag: v4.1.4
   labels:
     application-name: directpv.min.io
     application-type: CSIDriver

--- a/resources/base/Deployment.yaml
+++ b/resources/base/Deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
+  annotations:
+    directpv.min.io/image-tag: v4.1.4
   labels:
     application-name: directpv.min.io
     application-type: CSIDriver

--- a/resources/base/kustomization.yaml
+++ b/resources/base/kustomization.yaml
@@ -33,3 +33,18 @@ images:
   - name: quay.io/minio/csi-resizer
     digest: sha256:58fa627393f20892b105a137d27e236dfaec233a3a64980f84dcb15f38c21533
 
+patches:
+  - patch: |-
+      - op: replace
+        path: /metadata/annotations/directpv.min.io~1image-tag
+        value: v4.1.4
+    target:
+      kind: Deployment
+      name: controller
+  - patch: |-
+      - op: replace
+        path: /metadata/annotations/directpv.min.io~1image-tag
+        value: v4.1.4
+    target:
+      kind: DaemonSet
+      name: node-server

--- a/resources/v4.0/base/kustomization.yaml
+++ b/resources/v4.0/base/kustomization.yaml
@@ -8,3 +8,19 @@ resources:
 images:
   - name: quay.io/minio/directpv
     digest: sha256:98c23183f3abb8d9b6e0c300677605cc822e039fc81ce0e5dd8bef1006547627
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /metadata/annotations/directpv.min.io~1image-tag
+        value: v4.0.16
+    target:
+      kind: Deployment
+      name: controller
+  - patch: |-
+      - op: replace
+        path: /metadata/annotations/directpv.min.io~1image-tag
+        value: v4.0.16
+    target:
+      kind: DaemonSet
+      name: node-server


### PR DESCRIPTION
This PR brings back the image-tag annotation which can be used to identify the image version installer