### PR TITLE
Add mounts from /proc/1/mountinfo

### DIFF
--- a/pkg/device/probe_linux.go
+++ b/pkg/device/probe_linux.go
@@ -35,15 +35,15 @@ func newDevice(
 	majorMinor string,
 	udevData map[string]string,
 ) (device *Device, err error) {
-	var mountPoints []string
+	mountPoints := make(utils.StringSet)
 	for _, mountEntry := range mountInfo.FilterByMajorMinor(majorMinor).List() {
-		mountPoints = append(mountPoints, mountEntry.MountPoint)
+		mountPoints.Set(mountEntry.MountPoint)
 	}
 
 	device = &Device{
 		Name:        name,
 		MajorMinor:  majorMinor,
-		MountPoints: mountPoints,
+		MountPoints: mountPoints.ToSlice(),
 		CDROM:       cdroms.Exist(name),
 		SwapOn:      swaps.Exist(utils.AddDevPrefix(name)),
 		udevData:    udevData,

--- a/pkg/device/sync.go
+++ b/pkg/device/sync.go
@@ -195,12 +195,12 @@ func updateDrive(ctx context.Context, driveName string, deviceMap map[string][]d
 		mountPoint := types.GetDriveMountDir(drive.Status.FSUUID)
 		legacyMountPoint := path.Join(consts.LegacyAppRootDir, "mnt", drive.Status.FSUUID)
 
-		var mountPoints []string
+		mountPoints := make(utils.StringSet)
 		for _, mountEntry := range mountInfo.FilterByMountSource(devices[0].MajorMinor).FilterByRoot("/").List() {
 			switch mountEntry.MountPoint {
 			case mountPoint, legacyMountPoint:
 			default:
-				mountPoints = append(mountPoints, mountEntry.MountPoint)
+				mountPoints.Set(mountEntry.MountPoint)
 			}
 
 			check := func() error {
@@ -224,7 +224,7 @@ func updateDrive(ctx context.Context, driveName string, deviceMap map[string][]d
 		}
 
 		if len(mountPoints) != 0 {
-			klog.ErrorS(fmt.Errorf("device mounted outside of DirectPV"), "device", devices[0].Name, "mountPoints", mountPoints, "drive", drive.GetDriveID(), drive.GetDriveName())
+			klog.ErrorS(fmt.Errorf("device mounted outside of DirectPV"), "device", devices[0].Name, "mountPoints", mountPoints.ToSlice(), "drive", drive.GetDriveID(), drive.GetDriveName())
 		}
 
 		updated = syncDrive(drive, devices[0])

--- a/pkg/initrequest/event.go
+++ b/pkg/initrequest/event.go
@@ -235,13 +235,13 @@ func (handler *initRequestEventHandler) initDevice(device pkgdevice.Device, forc
 		return err
 	}
 
-	var mountPoints []string
+	mountPoints := make(utils.StringSet)
 	for _, mountEntry := range mountInfo.FilterByMajorMinor(device.MajorMinor).List() {
-		mountPoints = append(mountPoints, mountEntry.MountPoint)
+		mountPoints.Set(mountEntry.MountPoint)
 	}
 
 	if len(mountPoints) != 0 {
-		return fmt.Errorf("device %v mounted at %v", devPath, mountPoints)
+		return fmt.Errorf("device %v mounted at %v", devPath, mountPoints.ToSlice())
 	}
 
 	fsuuid := uuid.New().String()


### PR DESCRIPTION
Some systems do not expose all mount information in /proc/self/mountinfo. This PR fixes the issue by reading entries from /proc/self/mountinfo and /proc/1/mountinfo.