### PR TITLE
Show Drive ID in 'list drives' default output

### DIFF
--- a/cmd/kubectl-directpv/list_drives.go
+++ b/cmd/kubectl-directpv/list_drives.go
@@ -140,6 +140,7 @@ func listDrivesMain(ctx context.Context) {
 	}
 
 	headers := table.Row{
+		"DRIVE ID",
 		"NODE",
 		"NAME",
 		"MAKE",
@@ -147,9 +148,6 @@ func listDrivesMain(ctx context.Context) {
 		"FREE",
 		"VOLUMES",
 		"STATUS",
-	}
-	if wideOutput {
-		headers = append(headers, "DRIVE ID")
 	}
 	if showLabels {
 		headers = append(headers, "LABELS")
@@ -199,6 +197,7 @@ func listDrivesMain(ctx context.Context) {
 			driveMake = "-"
 		}
 		row := []interface{}{
+			drive.GetDriveID(),
 			drive.GetNodeID(),
 			drive.GetDriveName(),
 			driveMake,
@@ -206,9 +205,6 @@ func listDrivesMain(ctx context.Context) {
 			printableBytes(drive.Status.FreeCapacity),
 			volumes,
 			status,
-		}
-		if wideOutput {
-			row = append(row, drive.GetDriveID())
 		}
 		if showLabels {
 			row = append(row, labelsToString(drive.GetLabels()))

--- a/docs/drive-management.md
+++ b/docs/drive-management.md
@@ -73,12 +73,12 @@ To get information of drives from DirectPV, run the `list drives` command. Below
 
 ```sh
 $ kubectl directpv list drives
-┌────────┬──────┬──────┬─────────┬─────────┬─────────┬────────┐
-│ NODE   │ NAME │ MAKE │ SIZE    │ FREE    │ VOLUMES │ STATUS │
-├────────┼──────┼──────┼─────────┼─────────┼─────────┼────────┤
-│ master │ vdb  │ -    │ 512 MiB │ 506 MiB │ -       │ Ready  │
-│ node1  │ vdb  │ -    │ 512 MiB │ 506 MiB │ -       │ Ready  │
-└────────┴──────┴──────┴─────────┴─────────┴─────────┴────────┘
+┌──────────────────────────────────────┬────────┬──────┬──────┬─────────┬─────────┬───────────┬─────────┬────────┐
+│ DRIVE ID                             │ NODE   │ NAME │ MAKE │ SIZE    │ FREE    │ ALLOCATED │ VOLUMES │ STATUS │
+├──────────────────────────────────────┼────────┼──────┼──────┼─────────┼─────────┼───────────┼─────────┼────────┤
+│ 1b94751e-f97a-4cd0-89b6-af2c7657a8e7 │ master │ vdb  │ -    │ 512 MiB │ 512 MiB │ -         │ -       │ Ready  │
+│ b3e44552-a3b8-4233-bf78-ccff05956804 │ node1  │ vdb  │ -    │ 512 MiB │ 512 MiB │ -         │ -       │ Ready  │
+└──────────────────────────────────────┴────────┴──────┴──────┴─────────┴─────────┴───────────┴─────────┴────────┘
 ```
 
 Refer to the [list drives command](./command-reference.md#drives-command) for more information.

--- a/docs/volume-management.md
+++ b/docs/volume-management.md
@@ -13,12 +13,12 @@ To get information of volumes from DirectPV, run the `list volumes` command. Bel
 
 ```sh
 $ kubectl directpv list drives
-┌────────┬──────┬──────┬─────────┬─────────┬─────────┬────────┐
-│ NODE   │ NAME │ MAKE │ SIZE    │ FREE    │ VOLUMES │ STATUS │
-├────────┼──────┼──────┼─────────┼─────────┼─────────┼────────┤
-│ master │ vdb  │ -    │ 512 MiB │ 506 MiB │ -       │ Ready  │
-│ node1  │ vdb  │ -    │ 512 MiB │ 506 MiB │ -       │ Ready  │
-└────────┴──────┴──────┴─────────┴─────────┴─────────┴────────┘
+┌──────────────────────────────────────┬────────┬──────┬──────┬─────────┬─────────┬───────────┬─────────┬────────┐
+│ DRIVE ID                             │ NODE   │ NAME │ MAKE │ SIZE    │ FREE    │ ALLOCATED │ VOLUMES │ STATUS │
+├──────────────────────────────────────┼────────┼──────┼──────┼─────────┼─────────┼───────────┼─────────┼────────┤
+│ 1b94751e-f97a-4cd0-89b6-af2c7657a8e7 │ master │ vdb  │ -    │ 512 MiB │ 512 MiB │ -         │ -       │ Ready  │
+│ b3e44552-a3b8-4233-bf78-ccff05956804 │ node1  │ vdb  │ -    │ 512 MiB │ 512 MiB │ -         │ -       │ Ready  │
+└──────────────────────────────────────┴────────┴──────┴──────┴─────────┴─────────┴───────────┴─────────┴────────┘
 ```
 
 Refer to the [list volumes command](./command-reference.md#volumes-command) for more information.


### PR DESCRIPTION
In many support/debugging cases, the drive ID is asked every time. Previously it is shown only in `-o wide` output. This patch fixes to make it as default.